### PR TITLE
Switch queries and types to num_active_vals

### DIFF
--- a/packages/client/components/layouts/Statitstics.tsx
+++ b/packages/client/components/layouts/Statitstics.tsx
@@ -583,14 +583,14 @@ const Statitstics = ({ showCalculatingEpochs }: Props) => {
                                             title='Target'
                                             color='#343434'
                                             backgroundColor='#f5f5f5'
-                                            percent={1 - epoch.f_missing_target / epoch.f_num_vals}
+                                            percent={1 - epoch.f_missing_target / epoch.f_num_active_vals}
                                             tooltipColor='orange'
                                             tooltipContent={
                                                 <>
                                                     <span>
                                                         Missing Target: {epoch.f_missing_target?.toLocaleString()}
                                                     </span>
-                                                    <span>Attestations: {epoch.f_num_vals?.toLocaleString()}</span>
+                                                    <span>Attestations: {epoch.f_num_active_vals?.toLocaleString()}</span>
                                                 </>
                                             }
                                             widthTooltip={220}
@@ -601,14 +601,14 @@ const Statitstics = ({ showCalculatingEpochs }: Props) => {
                                             title='Source'
                                             color='#343434'
                                             backgroundColor='#f5f5f5'
-                                            percent={1 - epoch.f_missing_source / epoch.f_num_vals}
+                                            percent={1 - epoch.f_missing_source / epoch.f_num_active_vals}
                                             tooltipColor='blue'
                                             tooltipContent={
                                                 <>
                                                     <span>
                                                         Missing Source: {epoch.f_missing_source?.toLocaleString()}
                                                     </span>
-                                                    <span>Attestations: {epoch.f_num_vals?.toLocaleString()}</span>
+                                                    <span>Attestations: {epoch.f_num_active_vals?.toLocaleString()}</span>
                                                 </>
                                             }
                                             widthTooltip={220}
@@ -619,12 +619,12 @@ const Statitstics = ({ showCalculatingEpochs }: Props) => {
                                             title='Head'
                                             color='#343434'
                                             backgroundColor='#f5f5f5'
-                                            percent={1 - epoch.f_missing_head / epoch.f_num_vals}
+                                            percent={1 - epoch.f_missing_head / epoch.f_num_active_vals}
                                             tooltipColor='purple'
                                             tooltipContent={
                                                 <>
                                                     <span>Missing Head: {epoch.f_missing_head?.toLocaleString()}</span>
-                                                    <span>Attestations: {epoch.f_num_vals?.toLocaleString()}</span>
+                                                    <span>Attestations: {epoch.f_num_active_vals?.toLocaleString()}</span>
                                                 </>
                                             }
                                             widthTooltip={220}
@@ -823,12 +823,12 @@ const Statitstics = ({ showCalculatingEpochs }: Props) => {
                                 title='Target'
                                 color='#343434'
                                 backgroundColor='#f5f5f5'
-                                percent={1 - epoch.f_missing_target / epoch.f_num_vals}
+                                percent={1 - epoch.f_missing_target / epoch.f_num_active_vals}
                                 tooltipColor='orange'
                                 tooltipContent={
                                     <>
                                         <span>Missing Target: {epoch.f_missing_target?.toLocaleString()}</span>
-                                        <span>Attestations: {epoch.f_num_vals?.toLocaleString()}</span>
+                                        <span>Attestations: {epoch.f_num_active_vals?.toLocaleString()}</span>
                                     </>
                                 }
                                 widthTooltip={220}
@@ -838,12 +838,12 @@ const Statitstics = ({ showCalculatingEpochs }: Props) => {
                                 title='Source'
                                 color='#343434'
                                 backgroundColor='#f5f5f5'
-                                percent={1 - epoch.f_missing_source / epoch.f_num_vals}
+                                percent={1 - epoch.f_missing_source / epoch.f_num_active_vals}
                                 tooltipColor='blue'
                                 tooltipContent={
                                     <>
                                         <span>Missing Source: {epoch.f_missing_source?.toLocaleString()}</span>
-                                        <span>Attestations: {epoch.f_num_vals?.toLocaleString()}</span>
+                                        <span>Attestations: {epoch.f_num_active_vals?.toLocaleString()}</span>
                                     </>
                                 }
                                 widthTooltip={220}
@@ -853,12 +853,12 @@ const Statitstics = ({ showCalculatingEpochs }: Props) => {
                                 title='Head'
                                 color='#343434'
                                 backgroundColor='#f5f5f5'
-                                percent={1 - epoch.f_missing_head / epoch.f_num_vals}
+                                percent={1 - epoch.f_missing_head / epoch.f_num_active_vals}
                                 tooltipColor='purple'
                                 tooltipContent={
                                     <>
                                         <span>Missing Head: {epoch.f_missing_head?.toLocaleString()}</span>
-                                        <span>Attestations: {epoch.f_num_vals?.toLocaleString()}</span>
+                                        <span>Attestations: {epoch.f_num_active_vals?.toLocaleString()}</span>
                                     </>
                                 }
                                 widthTooltip={220}
@@ -902,7 +902,7 @@ const Statitstics = ({ showCalculatingEpochs }: Props) => {
                                 title='Attesting/Total active'
                                 color='#343434'
                                 backgroundColor='#f5f5f5'
-                                percent={epoch.f_num_att_vals / epoch.f_num_vals}
+                                percent={epoch.f_num_att_vals / epoch.f_num_active_vals}
                                 tooltipColor='bluedark'
                                 tooltipContent={
                                     <>

--- a/packages/client/types/index.ts
+++ b/packages/client/types/index.ts
@@ -2,7 +2,7 @@ export type Epoch = {
     f_epoch: number;
     f_slot: number;
     f_num_att_vals: number;
-    f_num_vals: number;
+    f_num_active_vals: number;
     f_att_effective_balance_eth: number;
     f_total_effective_balance_eth: number;
     f_missing_source: number;

--- a/packages/server/controllers/epochs.ts
+++ b/packages/server/controllers/epochs.ts
@@ -14,7 +14,7 @@ export const getEpochsStatistics = async (req: Request, res: Response) => {
         const [ epochsStats, blocksStats ] =
          await Promise.all([
             pgPool.query(`
-                SELECT f_epoch, f_slot, f_num_att_vals, f_num_vals, 
+                SELECT f_epoch, f_slot, f_num_att_vals, f_num_active_vals, 
                 f_att_effective_balance_eth, f_total_effective_balance_eth,
                 f_missing_source, f_missing_target, f_missing_head
                 FROM t_epoch_metrics_summary
@@ -67,7 +67,7 @@ export const getEpochById = async (req: Request, res: Response) => {
         const [ epochStats, blocksProposed, withdrawals ] = 
             await Promise.all([
                 pgPool.query(`
-                    SELECT f_epoch, f_slot, f_num_att_vals, f_num_vals, 
+                    SELECT f_epoch, f_slot, f_num_att_vals, f_num_active_vals, 
                     f_att_effective_balance_eth, f_total_effective_balance_eth,
                     f_missing_source, f_missing_target, f_missing_head
                     FROM t_epoch_metrics_summary


### PR DESCRIPTION
Since the database keeps growing, we now have different columns for the number of validator depending on the status.
Thus, the `f_num_vals` now represents the total number of validators, while the `f_num_active_vals` represents the active ones.
With this change, the workflow should be the same as before the change.

# Changes:
- num_vals -> num_active_vals