### PR TITLE
Expand epoch(s) page

### DIFF
--- a/packages/client/components/layouts/Epochs.tsx
+++ b/packages/client/components/layouts/Epochs.tsx
@@ -187,6 +187,63 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                 </div>
 
                 <div className='flex flex-col w-full'>
+                    <div className='flex gap-x-1 items-center justify-center mb-1'>
+                        <p className='mt-1 font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Attestations</p>
+                        <TooltipContainer>
+                            <CustomImage
+                                src='/static/images/icons/information_icon.webp'
+                                alt='Attestation Accuracy information'
+                                width={24}
+                                height={24}
+                            />
+
+                            <TooltipResponsive
+                                width={200}
+                                content={
+                                    <>
+                                        <span>Number of attestations included in blocks in the epochs</span>
+                                    </>
+                                }
+                                top='34px'
+                                polygonRight
+                            />
+                        </TooltipContainer>
+                    </div>
+
+                    <div>
+                        <p className='w-32 uppercase mx-auto text-center'>{calculatingText}</p>
+                    </div>
+                </div>
+
+                <div className='flex flex-col w-full'>
+                    <div className='flex gap-x-1 items-center justify-center mb-1'>
+                        <p className='mt-1 font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Withdrawals</p>
+                        <TooltipContainer>
+                            <CustomImage
+                                src='/static/images/icons/information_icon.webp'
+                                alt='Attestation Accuracy information'
+                                width={24}
+                                height={24}
+                            />
+
+                            <TooltipResponsive
+                                width={200}
+                                content={
+                                    <>
+                                        <span>Number of withdrawals included in the epoch</span>
+                                    </>
+                                }
+                                top='34px'
+                                polygonRight
+                            />
+                        </TooltipContainer>
+                    </div>
+                    <div>
+                        <p className='w-32 uppercase mx-auto text-center'>{calculatingText}</p>
+                    </div>
+                </div>
+
+                <div className='flex flex-col w-full'>
                     <div className='flex gap-x-1 justify-center mb-1'>
                         <p className='mt-1 font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Blocks</p>
                         <TooltipContainer>
@@ -545,6 +602,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                             <LinkIcon />
                         </LinkEpoch>
                     </div>
+
                     <div className='flex flex-col gap-x-4 w-full'>
                         <div className='flex gap-x-1 justify-center mb-1'>
                             <p className='mt-1 font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Time</p>
@@ -572,6 +630,60 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                         <div className='text-center'>
                             <p>{new Date(blockGenesis + epoch.f_epoch * 32 * 12000).toLocaleDateString('ja-JP')}</p>
                             <p>{new Date(blockGenesis + epoch.f_epoch * 32 * 12000).toLocaleTimeString('ja-JP')}</p>
+                        </div>
+                    </div>
+
+                    <div className='flex flex-col gap-x-4 w-full'>
+                        <div className='flex gap-x-1 justify-center mb-1'>
+                            <p className='mt-1 font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Attestations</p>
+                            <TooltipContainer>
+                                <CustomImage
+                                    src='/static/images/icons/information_icon.webp'
+                                    alt='Time information'
+                                    width={24}
+                                    height={24}
+                                />
+
+                                <TooltipResponsive
+                                    width={220}
+                                    content={
+                                        <>
+                                            <span>Number of attestations included in blocks in the epochs</span>
+                                        </>
+                                    }
+                                    top='34px'
+                                />
+                            </TooltipContainer>
+                        </div>
+                        <div className='text-center'>
+                            <p>{epoch?.f_num_att}</p>
+                        </div>
+                    </div>
+
+                    <div className='flex flex-col gap-x-4 w-full'>
+                        <div className='flex gap-x-1 justify-center mb-1'>
+                            <p className='mt-1 font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Withdrawals</p>
+                            <TooltipContainer>
+                                <CustomImage
+                                    src='/static/images/icons/information_icon.webp'
+                                    alt='Time information'
+                                    width={24}
+                                    height={24}
+                                />
+
+                                <TooltipResponsive
+                                    width={220}
+                                    content={
+                                        <>
+                                            <span>Number of withdrawals included in the epoch</span>
+                                        </>
+                                    }
+                                    top='34px'
+                                />
+                            </TooltipContainer>
+                        </div>
+                        <div className='text-center'>
+                            <p>{epoch?.f_withdrawals_num}</p>
                         </div>
                     </div>
 

--- a/packages/client/components/layouts/Epochs.tsx
+++ b/packages/client/components/layouts/Epochs.tsx
@@ -111,7 +111,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                     <p className='w-13 uppercase mx-auto text-center'>{calculatingText}</p>
                 </div>
 
-                <div className='w-[15%] pt-3.5 mb-5'>
+                <div className='w-[11%] pt-3.5 mb-5'>
                     <p className='uppercase text-center'>Blocks</p>
 
                     <ProgressTileBar
@@ -131,11 +131,11 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                     />
                 </div>
 
-                <div className='w-[32%]'>
+                <div className='w-[34%]'>
                     <p className='w-32 uppercase mx-auto text-start'>{calculatingText}</p>
                 </div>
 
-                <div className='w-[32%]'>
+                <div className='w-[22%]'>
                     <p className='w-32 uppercase mx-auto text-start'>{calculatingText}</p>
                 </div>
             </LargeTableRow>

--- a/packages/client/components/layouts/Epochs.tsx
+++ b/packages/client/components/layouts/Epochs.tsx
@@ -434,13 +434,13 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
             <LargeTableHeader
                 text='Deposits/Withdrawals'
                 width='25%'
-                tooltipContent={<TooltipResponsive width={150} content={<span>Number of withdrawals included in the epoch</span>} top='34px' />}
+                tooltipContent={<TooltipResponsive width={200} content={<span>Number of eth2 deposits and withdrawals included in the epoch</span>} top='34px' />}
             />
 
             <LargeTableHeader
                 text='Slashing P / A'
                 width='18%'
-                tooltipContent={<TooltipResponsive width={150} content={<span>Number of new proposer and attester slashings included in the epoch</span>} top='34px' />}
+                tooltipContent={<TooltipResponsive width={200} content={<span>Number of new proposer and attester slashings included in the epoch</span>} top='34px' />}
             />
 
             <LargeTableHeader

--- a/packages/client/components/layouts/Epochs.tsx
+++ b/packages/client/components/layouts/Epochs.tsx
@@ -555,7 +555,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                                     tooltipContent={
                                         <>
                                             <span>Missing Source: {epoch.f_missing_source?.toLocaleString()}</span>
-                                            <span>Attestations: {epoch.f_num_active_vals?.toLocaleString()}</span>
+                                            <span>Attestating Validators: {epoch.f_num_active_vals?.toLocaleString()}</span>
                                         </>
                                     }
                                     widthTooltip={220}
@@ -573,7 +573,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                                     tooltipContent={
                                         <>
                                             <span>Missing Target: {epoch.f_missing_target?.toLocaleString()}</span>
-                                            <span>Attestations: {epoch.f_num_active_vals?.toLocaleString()}</span>
+                                            <span>Attestasting Validators: {epoch.f_num_active_vals?.toLocaleString()}</span>
                                         </>
                                     }
                                     widthTooltip={220}
@@ -591,7 +591,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                                     tooltipContent={
                                         <>
                                             <span>Missing Head: {epoch.f_missing_head?.toLocaleString()}</span>
-                                            <span>Attestations: {epoch.f_num_active_vals?.toLocaleString()}</span>
+                                            <span>Attesting Validators: {epoch.f_num_active_vals?.toLocaleString()}</span>
                                         </>
                                     }
                                     widthTooltip={220}
@@ -830,7 +830,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                             tooltipContent={
                                 <>
                                     <span>Missing Source: {epoch.f_missing_source?.toLocaleString()}</span>
-                                    <span>Attestations: {epoch.f_num_active_vals?.toLocaleString()}</span>
+                                    <span>Attesting Validators: {epoch.f_num_active_vals?.toLocaleString()}</span>
                                 </>
                             }
                             widthTooltip={220}
@@ -845,7 +845,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                             tooltipContent={
                                 <>
                                     <span>Missing Target: {epoch.f_missing_target?.toLocaleString()}</span>
-                                    <span>Attestations: {epoch.f_num_active_vals?.toLocaleString()}</span>
+                                    <span>Attesting Validators: {epoch.f_num_active_vals?.toLocaleString()}</span>
                                 </>
                             }
                             widthTooltip={220}
@@ -860,7 +860,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                             tooltipContent={
                                 <>
                                     <span>Missing Head: {epoch.f_missing_head?.toLocaleString()}</span>
-                                    <span>Attestations: {epoch.f_num_active_vals?.toLocaleString()}</span>
+                                    <span>Attesting Validators: {epoch.f_num_active_vals?.toLocaleString()}</span>
                                 </>
                             }
                             widthTooltip={220}

--- a/packages/client/components/layouts/Epochs.tsx
+++ b/packages/client/components/layouts/Epochs.tsx
@@ -439,13 +439,13 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
 
             <LargeTableHeader
                 text='Slashing P / A'
-                width='18%'
+                width='19%'
                 tooltipContent={<TooltipResponsive width={200} content={<span>Number of new proposer and attester slashings included in the epoch</span>} top='34px' />}
             />
 
             <LargeTableHeader
                 text='Blocks'
-                width='15%'
+                width='11%'
                 tooltipContent={
                     <TooltipResponsive
                         width={220}
@@ -463,7 +463,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
 
             <LargeTableHeader
                 text='Attestation Accuracy'
-                width='32%'
+                width='34%'
                 tooltipContent={
                     <TooltipResponsive
                         width={240}
@@ -481,7 +481,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
 
             <LargeTableHeader
                 text='Voting Participation'
-                width='32%'
+                width='22%'
                 tooltipContent={
                     <TooltipResponsive
                         width={180}
@@ -528,8 +528,8 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                         <p>{epoch?.f_new_proposer_slashings}/{epoch?.f_new_attester_slashings}</p>
                     </div>
 
-                    <div className='w-[15%] pt-3.5 mb-5'>
-                        <p className='uppercase text-center'>Blocks</p>
+                    <div className='w-[14%] pt-3.5 mb-5 m-1'>
+                        <p className='uppercase text-center mb-2'>Blocks</p>
 
                         <ProgressTileBar
                             totalBlocks={epoch.proposed_blocks}
@@ -543,7 +543,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                         />
                     </div>
 
-                    <div className='w-[32%] mb-2'>
+                    <div className='w-[32%] m-2'>
                         <div className='flex gap-x-1 justify-center'>
                             <div className='flex-1'>
                                 <ProgressSmoothBar
@@ -601,7 +601,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                         </div>
                     </div>
 
-                    <div className='w-[32%] mb-2'>
+                    <div className='w-[20%] m-2'>
                         <ProgressSmoothBar
                             title='Attesting/Total active'
                             color='#343434'

--- a/packages/client/components/layouts/Epochs.tsx
+++ b/packages/client/components/layouts/Epochs.tsx
@@ -99,11 +99,15 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                     <LinkEpoch epoch={f_epoch} mxAuto />
                 </div>
 
-                <div className='w-[13%]'>
+                <div className='w-[15%]'>
                     <p className='w-13 uppercase mx-auto text-center'>{calculatingText}</p>
                 </div>
 
-                <div className='w-[13%]'>
+                <div className='w-[25%]'>
+                    <p className='w-13 uppercase mx-auto text-center'>{calculatingText}</p>
+                </div>
+
+                <div className='w-[18%]'>
                     <p className='w-13 uppercase mx-auto text-center'>{calculatingText}</p>
                 </div>
 
@@ -217,7 +221,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
 
                 <div className='flex flex-col w-full'>
                     <div className='flex gap-x-1 items-center justify-center mb-1'>
-                        <p className='mt-1 font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Withdrawals</p>
+                    <p className='mt-1 font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Deposits/Withdrawals</p>
                         <TooltipContainer>
                             <CustomImage
                                 src='/static/images/icons/information_icon.webp'
@@ -230,7 +234,35 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                                 width={200}
                                 content={
                                     <>
-                                        <span>Number of withdrawals included in the epoch</span>
+                                        <span>Number of eth2 deposits and withdrawals included in the epoch</span>
+                                    </>
+                                }
+                                top='34px'
+                                polygonRight
+                            />
+                        </TooltipContainer>
+                    </div>
+                    <div>
+                        <p className='w-32 uppercase mx-auto text-center'>{calculatingText}</p>
+                    </div>
+                </div>
+
+                <div className='flex flex-col w-full'>
+                    <div className='flex gap-x-1 items-center justify-center mb-1'>
+                    <p className='mt-1 font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Slashing P / A</p>
+                        <TooltipContainer>
+                            <CustomImage
+                                src='/static/images/icons/information_icon.webp'
+                                alt='Attestation Accuracy information'
+                                width={24}
+                                height={24}
+                            />
+
+                            <TooltipResponsive
+                                width={200}
+                                content={
+                                    <>
+                                        <span>Number of new proposer and attester slashings included in the epoch</span>
                                     </>
                                 }
                                 top='34px'
@@ -395,16 +427,21 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
 
             <LargeTableHeader
                 text='Attestations'
-                width='13%'
+                width='15%'
                 tooltipContent={<TooltipResponsive width={220} content={<span>Number of attestations included in blocks in the epochs</span>} top='34px' />}
             />
 
             <LargeTableHeader
-                text='Withdrawals'
-                width='13%'
+                text='Deposits/Withdrawals'
+                width='25%'
                 tooltipContent={<TooltipResponsive width={150} content={<span>Number of withdrawals included in the epoch</span>} top='34px' />}
             />
 
+            <LargeTableHeader
+                text='Slashing P / A'
+                width='18%'
+                tooltipContent={<TooltipResponsive width={150} content={<span>Number of new proposer and attester slashings included in the epoch</span>} top='34px' />}
+            />
 
             <LargeTableHeader
                 text='Blocks'
@@ -479,12 +516,16 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                         <LinkEpoch epoch={epoch.f_epoch} mxAuto />
                     </div>
 
-                    <div className='w-[13%] flex flex-col text-center'>
-                        <p>{epoch.f_num_att}</p>
+                    <div className='w-[15%] flex flex-col text-center'>
+                        <p>{epoch?.f_num_att}</p>
                     </div>
 
-                    <div className='w-[13%] flex flex-col text-center'>
-                        <p>{epoch.f_withdrawals_num}</p>
+                    <div className='w-[25%] flex flex-col text-center'>
+                        <p>{epoch?.f_deposits_num}/{epoch?.f_withdrawals_num}</p>
+                    </div>
+
+                    <div className='w-[18%] flex flex-col text-center'>
+                        <p>{epoch?.f_new_proposer_slashings}/{epoch?.f_new_attester_slashings}</p>
                     </div>
 
                     <div className='w-[15%] pt-3.5 mb-5'>
@@ -662,7 +703,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
 
                     <div className='flex flex-col gap-x-4 w-full'>
                         <div className='flex gap-x-1 justify-center mb-1'>
-                            <p className='mt-1 font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Withdrawals</p>
+                            <p className='mt-1 font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Deposits/Withdrawals</p>
                             <TooltipContainer>
                                 <CustomImage
                                     src='/static/images/icons/information_icon.webp'
@@ -675,7 +716,7 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                                     width={220}
                                     content={
                                         <>
-                                            <span>Number of withdrawals included in the epoch</span>
+                                            <span>Number of eth2 deposits and withdrawals included in the epoch</span>
                                         </>
                                     }
                                     top='34px'
@@ -683,9 +724,37 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                             </TooltipContainer>
                         </div>
                         <div className='text-center'>
-                            <p>{epoch?.f_withdrawals_num}</p>
+                            <p>{epoch?.f_deposits_num}/{epoch?.f_withdrawals_num}</p>
                         </div>
                     </div>
+
+                    <div className='flex flex-col gap-x-4 w-full'>
+                        <div className='flex gap-x-1 justify-center mb-1'>
+                            <p className='mt-1 font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Slashing P / A</p>
+                            <TooltipContainer>
+                                <CustomImage
+                                    src='/static/images/icons/information_icon.webp'
+                                    alt='Time information'
+                                    width={24}
+                                    height={24}
+                                />
+
+                                <TooltipResponsive
+                                    width={220}
+                                    content={
+                                        <>
+                                            <span>Number of new proposer and attester slashings included in the epoch</span>
+                                        </>
+                                    }
+                                    top='34px'
+                                />
+                            </TooltipContainer>
+                        </div>
+                        <div className='text-center'>
+                            <p>{epoch?.f_new_proposer_slashings}/{epoch?.f_new_attester_slashings}</p>
+                        </div>
+                    </div>
+
 
                     <div className='flex flex-col w-full'>
                         <div className='flex gap-x-1 justify-center mb-1'>

--- a/packages/client/components/layouts/Epochs.tsx
+++ b/packages/client/components/layouts/Epochs.tsx
@@ -99,6 +99,14 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
                     <LinkEpoch epoch={f_epoch} mxAuto />
                 </div>
 
+                <div className='w-[13%]'>
+                    <p className='w-13 uppercase mx-auto text-center'>{calculatingText}</p>
+                </div>
+
+                <div className='w-[13%]'>
+                    <p className='w-13 uppercase mx-auto text-center'>{calculatingText}</p>
+                </div>
+
                 <div className='w-[15%] pt-3.5 mb-5'>
                     <p className='uppercase text-center'>Blocks</p>
 
@@ -329,6 +337,19 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
             />
 
             <LargeTableHeader
+                text='Attestations'
+                width='13%'
+                tooltipContent={<TooltipResponsive width={220} content={<span>Number of attestations included in blocks in the epochs</span>} top='34px' />}
+            />
+
+            <LargeTableHeader
+                text='Withdrawals'
+                width='13%'
+                tooltipContent={<TooltipResponsive width={150} content={<span>Number of withdrawals included in the epoch</span>} top='34px' />}
+            />
+
+
+            <LargeTableHeader
                 text='Blocks'
                 width='15%'
                 tooltipContent={
@@ -399,6 +420,14 @@ const Epochs = ({ epochs, blocksPerEpoch, showCalculatingEpochs, fetchingEpochs,
 
                     <div className='w-[11%] font-medium md:hover:underline underline-offset-4 decoration-2 text-[var(--darkPurple)] dark:text-[var(--purple)]'>
                         <LinkEpoch epoch={epoch.f_epoch} mxAuto />
+                    </div>
+
+                    <div className='w-[13%] flex flex-col text-center'>
+                        <p>{epoch.f_num_att}</p>
+                    </div>
+
+                    <div className='w-[13%] flex flex-col text-center'>
+                        <p>{epoch.f_withdrawals_num}</p>
                     </div>
 
                     <div className='w-[15%] pt-3.5 mb-5'>

--- a/packages/client/components/layouts/Slots.tsx
+++ b/packages/client/components/layouts/Slots.tsx
@@ -141,17 +141,17 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
 
                     <p className='w-[15%] text-center'>{(slot.f_block) ? getShortAddress(slot.f_block) : "N/A"}</p>
 
-                    <p className='w-[10%] text-center'>{slot.f_attestations}</p>
+                    <p className='w-[10%] text-center'>{(slot?.f_attestations === 0) ? "-" : slot.f_attestations}</p>
 
-                    <p className='w-[15%] text-center'>{(slot.f_sync_bits * 100 / 512).toFixed(2)}%</p>
+                    <p className='w-[15%] text-center'>{(slot?.f_attestations === 0) ? '-' : `${(slot.f_sync_bits * 100 / 512).toFixed(2)}%`}</p>
 
-                    <p className='w-[10%] text-center'>{slot.f_deposits}</p>
+                    <p className='w-[10%] text-center'>{(slot?.f_attestations === 0) ? '-' : slot.f_deposits}</p>
 
-                    <p className='w-[10%] text-center'>{slot.f_proposer_slashings}/{slot.f_attester_slashings}</p>
+                    <p className='w-[10%] text-center'>{(slot?.f_attestations === 0) ? '-' : `${slot.f_proposer_slashings}/${slot.f_attester_slashings}`}</p>
 
-                    <p className='w-[10%] text-center'>{slot.f_voluntary_exits}</p>
+                    <p className='w-[10%] text-center'>{(slot.f_attestations === 0) ? '-' : slot.f_voluntary_exits}</p>
 
-                    <p className='w-[15%] text-center'>{slot.num_withdrawals} ({(slot.withdrawals / 10 ** 9).toLocaleString()} ETH)</p>
+                    <p className='w-[15%] text-center'>{(slot.f_attestations === 0) ? '-' : `${slot.num_withdrawals} (${(slot.withdrawals / 10 ** 9).toLocaleString()}) ETH`}</p>
                 </LargeTableRow>
             ))}
         </LargeTable>
@@ -211,14 +211,14 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Attestations:
                                 </p>
-                                <p>{slot.f_attestations}</p>
+                                <p>{(slot?.f_attestations === 0) ? "-" : slot.f_attestations}</p>
                             </div>
 
                             <div className='flex items-center justify-between'>
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Sync Agg %:
                                 </p>
-                                <p>{(slot.f_sync_bits * 100 / 512).toFixed(2)}%</p>
+                                <p>{(slot?.f_attestations === 0) ? '-' : (slot.f_sync_bits * 100 / 512).toFixed(2)}%</p>
                             </div>
 
                             <div className='flex items-center justify-between'>
@@ -232,21 +232,21 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Slashing P / A:
                                 </p>
-                                <p>{slot.f_proposer_slashings}/{slot.f_attester_slashings}</p>
+                                <p>{(slot?.f_attestations === 0) ? '-' : `${slot.f_proposer_slashings}/${slot.f_attester_slashings}`}</p>
                             </div>
 
                             <div className='flex items-center justify-between'>
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Exits:
                                 </p>
-                                <p>{slot.f_voluntary_exits}</p>
+                                <p>{(slot.f_attestations === 0) ? '-' : slot.f_voluntary_exits}</p>
                             </div>
 
                             <div className='flex items-center justify-between'>
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Withdrawals:
                                 </p>
-                                <p>{slot.num_withdrawals}({(slot.withdrawals / 10 ** 9).toLocaleString()} ETH)</p>
+                                <p>{(slot.f_attestations === 0) ? '-' : slot.num_withdrawals}({(slot.withdrawals / 10 ** 9).toLocaleString()} ETH)</p>
                             </div>
                         </div>
                     </div>

--- a/packages/client/components/layouts/Slots.tsx
+++ b/packages/client/components/layouts/Slots.tsx
@@ -151,7 +151,7 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
 
                     <p className='w-[10%] text-center'>{slot.f_voluntary_exits}</p>
 
-                    <p className='w-[15%] text-center'>{slot.withdrawals}({(slot.withdrawals / 10 ** 9).toLocaleString()}) ETH</p>
+                    <p className='w-[15%] text-center'>{slot.num_withdrawals}({(slot.withdrawals / 10 ** 9).toLocaleString()} ETH)</p>
                 </LargeTableRow>
             ))}
         </LargeTable>
@@ -246,7 +246,7 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Withdrawals:
                                 </p>
-                                <p>{(slot.withdrawals / 10 ** 9).toLocaleString()} ETH</p>
+                                <p>{slot.num_withdrawals}({(slot.withdrawals / 10 ** 9).toLocaleString()} ETH)</p>
                             </div>
                         </div>
                     </div>

--- a/packages/client/components/layouts/Slots.tsx
+++ b/packages/client/components/layouts/Slots.tsx
@@ -91,7 +91,7 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                     </div>
 
                     <div className='w-[15%] md:hover:underline underline-offset-4 decoration-2 text-[var(--darkPurple)] dark:text-[var(--purple)]'>
-                        <LinkValidator validator={slot["pd.f_val_idx"]} mxAuto />
+                        <LinkValidator validator={slot.f_val_idx} mxAuto />
                     </div>
 
                     <div className='w-[15%] md:hover:underline underline-offset-4 decoration-2 text-[var(--darkPurple)] dark:text-[var(--purple)]'>
@@ -111,7 +111,7 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
 
                     <p className='w-[10%] text-center'>{slot.f_attestations}</p>
 
-                    <p className='w-[10%] text-center'>{(slot.f_sync_bits * 100 / 512).toFixed(2)}%</p>
+                    <p className='w-[12%] text-center'>{(slot.f_sync_bits * 100 / 512).toFixed(2)}%</p>
 
                     <p className='w-[10%] text-center'>{slot.f_deposits}</p>
 
@@ -166,6 +166,48 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                                         ).toLocaleTimeString('ja-JP')}
                                     </p>
                                 </div>
+                            </div>
+
+                            <div className='flex items-center justify-between'>
+                                <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
+                                    Root Hash:
+                                </p>
+                                <p>{(slot.f_block) ? getShortAddress(slot.f_block) : "N/A"}</p>
+                            </div>
+
+                            <div className='flex items-center justify-between'>
+                                <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
+                                    Attestations:
+                                </p>
+                                <p>{slot.f_attestations}</p>
+                            </div>
+
+                            <div className='flex items-center justify-between'>
+                                <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
+                                    Sync Agg %:
+                                </p>
+                                <p>{(slot.f_sync_bits * 100 / 512).toFixed(2)}%</p>
+                            </div>
+
+                            <div className='flex items-center justify-between'>
+                                <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
+                                    Deposits:
+                                </p>
+                                <p>{slot.f_deposits}</p>
+                            </div>
+
+                            <div className='flex items-center justify-between'>
+                                <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
+                                    Slashing P / A:
+                                </p>
+                                <p>{slot.f_proposer_slashings}/{slot.f_attester_slashings}</p>
+                            </div>
+
+                            <div className='flex items-center justify-between'>
+                                <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
+                                    Exits:
+                                </p>
+                                <p>{slot.f_voluntary_exits}</p>
                             </div>
 
                             <div className='flex items-center justify-between'>

--- a/packages/client/components/layouts/Slots.tsx
+++ b/packages/client/components/layouts/Slots.tsx
@@ -151,7 +151,7 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
 
                     <p className='w-[10%] text-center'>{slot.f_voluntary_exits}</p>
 
-                    <p className='w-[15%] text-center'>{slot.num_withdrawals}({(slot.withdrawals / 10 ** 9).toLocaleString()} ETH)</p>
+                    <p className='w-[15%] text-center'>{slot.num_withdrawals} ({(slot.withdrawals / 10 ** 9).toLocaleString()} ETH)</p>
                 </LargeTableRow>
             ))}
         </LargeTable>

--- a/packages/client/components/layouts/Slots.tsx
+++ b/packages/client/components/layouts/Slots.tsx
@@ -16,6 +16,7 @@ import { LargeTable, LargeTableHeader, LargeTableRow, SmallTable, SmallTableCard
 
 // Types
 import { Slot } from '../../types';
+import { getShortAddress } from '../../helpers/addressHelper';
 
 // Props
 type Props = {
@@ -55,7 +56,7 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
             console.log(error);
         }
     };
-
+    console.log(slots);
     // Slots Large View
     const getContentSlotsLargeView = () => (
         <LargeTable minWidth={850} noRowsText='No Slots' fetchingRows={fetchingSlots}>
@@ -64,6 +65,13 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
             <LargeTableHeader text='Proposer' width='15%' />
             <LargeTableHeader text='Slot' width='15%' />
             <LargeTableHeader text='Time' width='10%' />
+            <LargeTableHeader text='Root Hash' width='15%' />
+            <LargeTableHeader text='Att' width='10%' />
+            <LargeTableHeader text='Sync Agg %' width='12%' />
+
+            <LargeTableHeader text='Deposits' width='10%' />
+            <LargeTableHeader text='S- P / A' width='10%' />
+            <LargeTableHeader text='Exits' width='10%' />
             <LargeTableHeader text='Withdrawals' width='15%' />
 
             {slots.map(slot => (
@@ -83,7 +91,7 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                     </div>
 
                     <div className='w-[15%] md:hover:underline underline-offset-4 decoration-2 text-[var(--darkPurple)] dark:text-[var(--purple)]'>
-                        <LinkValidator validator={slot.f_val_idx} mxAuto />
+                        <LinkValidator validator={slot["pd.f_val_idx"]} mxAuto />
                     </div>
 
                     <div className='w-[15%] md:hover:underline underline-offset-4 decoration-2 text-[var(--darkPurple)] dark:text-[var(--purple)]'>
@@ -98,6 +106,18 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                             {new Date(blockGenesis + Number(slot.f_proposer_slot) * 12000).toLocaleTimeString('ja-JP')}
                         </span>
                     </div>
+
+                    <p className='w-[15%] text-center'>{(slot.f_block) ? getShortAddress(slot.f_block) : "N/A"}</p>
+
+                    <p className='w-[10%] text-center'>{slot.f_attestations}</p>
+
+                    <p className='w-[10%] text-center'>{(slot.f_sync_bits * 100 / 512).toFixed(2)}%</p>
+
+                    <p className='w-[10%] text-center'>{slot.f_deposits}</p>
+
+                    <p className='w-[10%] text-center'>{slot.f_proposer_slashings}/{slot.f_attester_slashings}</p>
+
+                    <p className='w-[10%] text-center'>{slot.f_voluntary_exits}</p>
 
                     <p className='w-[15%] text-center'>{(slot.withdrawals / 10 ** 9).toLocaleString()} ETH</p>
                 </LargeTableRow>

--- a/packages/client/components/layouts/Slots.tsx
+++ b/packages/client/components/layouts/Slots.tsx
@@ -56,7 +56,7 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
             console.log(error);
         }
     };
-    console.log(slots);
+
     // Slots Large View
     const getContentSlotsLargeView = () => (
         <LargeTable minWidth={850} noRowsText='No Slots' fetchingRows={fetchingSlots}>

--- a/packages/client/components/layouts/Slots.tsx
+++ b/packages/client/components/layouts/Slots.tsx
@@ -149,9 +149,9 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
 
                     <p className='w-[10%] text-center'>{(slot?.f_attestations === 0) ? '-' : `${slot.f_proposer_slashings}/${slot.f_attester_slashings}`}</p>
 
-                    <p className='w-[10%] text-center'>{(slot.f_attestations === 0) ? '-' : slot.f_voluntary_exits}</p>
+                    <p className='w-[10%] text-center'>{(slot?.f_attestations === 0) ? '-' : slot.f_voluntary_exits}</p>
 
-                    <p className='w-[15%] text-center'>{(slot.f_attestations === 0) ? '-' : `${slot.num_withdrawals} (${(slot.withdrawals / 10 ** 9).toLocaleString()}) ETH`}</p>
+                    <p className='w-[15%] text-center'>{(slot?.f_attestations === 0) ? '-' : `${slot.num_withdrawals} (${(slot.withdrawals / 10 ** 9).toLocaleString()}) ETH`}</p>
                 </LargeTableRow>
             ))}
         </LargeTable>
@@ -225,7 +225,7 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Deposits:
                                 </p>
-                                <p>{slot.f_deposits}</p>
+                                <p>{(slot?.f_attestations === 0) ? "-" : slot.f_deposits}</p>
                             </div>
 
                             <div className='flex items-center justify-between'>
@@ -239,14 +239,14 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Exits:
                                 </p>
-                                <p>{(slot.f_attestations === 0) ? '-' : slot.f_voluntary_exits}</p>
+                                <p>{(slot?.f_attestations === 0) ? '-' : slot.f_voluntary_exits}</p>
                             </div>
 
                             <div className='flex items-center justify-between'>
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Withdrawals:
                                 </p>
-                                <p>{(slot.f_attestations === 0) ? '-' : slot.num_withdrawals}({(slot.withdrawals / 10 ** 9).toLocaleString()} ETH)</p>
+                                <p>{(slot?.f_attestations === 0) ? '-' : slot.num_withdrawals}({(slot.withdrawals / 10 ** 9).toLocaleString()} ETH)</p>
                             </div>
                         </div>
                     </div>

--- a/packages/client/components/layouts/Slots.tsx
+++ b/packages/client/components/layouts/Slots.tsx
@@ -138,17 +138,17 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                         </span>
                     </div>
 
-                    <p className='w-[10%] text-center'>{(slot?.f_attestations === 0) ? "-" : slot.f_attestations}</p>
+                    <p className='w-[10%] text-center'>{(slot.f_proposed === false) ? "-" : slot.f_attestations}</p>
 
-                    <p className='w-[15%] text-center'>{(slot?.f_attestations === 0) ? '-' : `${(slot.f_sync_bits * 100 / 512).toFixed(2)}%`}</p>
+                    <p className='w-[15%] text-center'>{(slot.f_proposed === false) ? '-' : `${(slot.f_sync_bits * 100 / 512).toFixed(2)}%`}</p>
 
-                    <p className='w-[10%] text-center'>{(slot?.f_attestations === 0) ? '-' : slot.f_deposits}</p>
+                    <p className='w-[10%] text-center'>{(slot.f_proposed === false) ? '-' : slot.f_deposits}</p>
 
-                    <p className='w-[10%] text-center'>{(slot?.f_attestations === 0) ? '-' : `${slot.f_proposer_slashings}/${slot.f_attester_slashings}`}</p>
+                    <p className='w-[10%] text-center'>{(slot.f_proposed === false) ? '-' : `${slot.f_proposer_slashings}/${slot.f_attester_slashings}`}</p>
 
-                    <p className='w-[10%] text-center'>{(slot?.f_attestations === 0) ? '-' : slot.f_voluntary_exits}</p>
+                    <p className='w-[10%] text-center'>{(slot.f_proposed === false) ? '-' : slot.f_voluntary_exits}</p>
 
-                    <p className='w-[15%] text-center'>{(slot?.f_attestations === 0) ? '-' : `${slot.num_withdrawals} (${(slot.withdrawals / 10 ** 9).toLocaleString()}) ETH`}</p>
+                    <p className='w-[15%] text-center'>{(slot.f_proposed === false) ? '-' : `${slot.num_withdrawals} (${(slot.withdrawals / 10 ** 9).toLocaleString()}) ETH`}</p>
                 </LargeTableRow>
             ))}
         </LargeTable>
@@ -201,42 +201,42 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Attestations:
                                 </p>
-                                <p>{(slot?.f_attestations === 0) ? "-" : slot.f_attestations}</p>
+                                <p>{(slot.f_proposed === false) ? "-" : slot.f_attestations}</p>
                             </div>
 
                             <div className='flex items-center justify-between'>
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Sync Agg %:
                                 </p>
-                                <p>{(slot?.f_attestations === 0) ? '-' : (slot.f_sync_bits * 100 / 512).toFixed(2)}%</p>
+                                <p>{(slot.f_proposed === false) ? '-' : (slot.f_sync_bits * 100 / 512).toFixed(2)}%</p>
                             </div>
 
                             <div className='flex items-center justify-between'>
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Deposits:
                                 </p>
-                                <p>{(slot?.f_attestations === 0) ? "-" : slot.f_deposits}</p>
+                                <p>{(slot.f_proposed === false) ? "-" : slot.f_deposits}</p>
                             </div>
 
                             <div className='flex items-center justify-between'>
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Slashing P / A:
                                 </p>
-                                <p>{(slot?.f_attestations === 0) ? '-' : `${slot.f_proposer_slashings}/${slot.f_attester_slashings}`}</p>
+                                <p>{(slot.f_proposed === false) ? '-' : `${slot.f_proposer_slashings}/${slot.f_attester_slashings}`}</p>
                             </div>
 
                             <div className='flex items-center justify-between'>
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Exits:
                                 </p>
-                                <p>{(slot?.f_attestations === 0) ? '-' : slot.f_voluntary_exits}</p>
+                                <p>{(slot.f_proposed === false) ? '-' : slot.f_voluntary_exits}</p>
                             </div>
 
                             <div className='flex items-center justify-between'>
                                 <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
                                     Withdrawals:
                                 </p>
-                                <p>{(slot?.f_attestations === 0) ? '-' : slot.num_withdrawals}({(slot.withdrawals / 10 ** 9).toLocaleString()} ETH)</p>
+                                <p>{(slot.f_proposed === false) ? '-' : slot.num_withdrawals}({(slot.withdrawals / 10 ** 9).toLocaleString()} ETH)</p>
                             </div>
                         </div>
                     </div>

--- a/packages/client/components/layouts/Slots.tsx
+++ b/packages/client/components/layouts/Slots.tsx
@@ -13,6 +13,8 @@ import LinkSlot from '../../components/ui/LinkSlot';
 import LinkEntity from '../../components/ui/LinkEntity';
 import BlockState from '../ui/BlockState';
 import { LargeTable, LargeTableHeader, LargeTableRow, SmallTable, SmallTableCard } from '../ui/Table';
+import TooltipResponsive from '../ui/TooltipResponsive';
+
 
 // Types
 import { Slot } from '../../types';
@@ -60,23 +62,53 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
     // Slots Large View
     const getContentSlotsLargeView = () => (
         <LargeTable minWidth={850} noRowsText='No Slots' fetchingRows={fetchingSlots}>
-            <LargeTableHeader text='Block' width='17%' />
-            <LargeTableHeader text='Entity' width='28%' />
-            <LargeTableHeader text='Proposer' width='15%' />
-            <LargeTableHeader text='Slot' width='15%' />
+            <LargeTableHeader text='Block' width='11%' />
+            <LargeTableHeader text='Entity' width='25%' />
+            <LargeTableHeader text='Proposer' width='12%' />
+            <LargeTableHeader text='Slot' width='12%' />
             <LargeTableHeader text='Time' width='10%' />
             <LargeTableHeader text='Root Hash' width='15%' />
-            <LargeTableHeader text='Att' width='10%' />
-            <LargeTableHeader text='Sync Agg %' width='12%' />
+            <LargeTableHeader text='Att' width='10%' tooltipContent={
+                    <TooltipResponsive
+                        width={220}
+                        content={
+                            <>
+                                <span>Attestations included in slot</span>
+                            </>
+                        }
+                        top='34px'
+                    />
+                }/>
+            <LargeTableHeader text='Sync Agg %' width='15%' tooltipContent={
+                    <TooltipResponsive
+                        width={220}
+                        content={
+                            <>
+                                <span>Sync Aggregate Participation</span>
+                            </>
+                        }
+                        top='34px'
+                    />
+                }/>
 
             <LargeTableHeader text='Deposits' width='10%' />
-            <LargeTableHeader text='S- P / A' width='10%' />
+            <LargeTableHeader text='S- P / A' width='10%' tooltipContent={
+                    <TooltipResponsive
+                        width={220}
+                        content={
+                            <>
+                                <span>Slashings Proposer / Attester</span>
+                            </>
+                        }
+                        top='34px'
+                    />
+                }/>
             <LargeTableHeader text='Exits' width='10%' />
             <LargeTableHeader text='Withdrawals' width='15%' />
 
             {slots.map(slot => (
                 <LargeTableRow key={slot.f_proposer_slot}>
-                    <div className='w-[17%] flex items-center justify-center'>
+                    <div className='w-[11%] flex items-center justify-center'>
                         <BlockState
                             poolName={slot.f_pool_name}
                             proposed={slot.f_proposed}
@@ -86,15 +118,15 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                         />
                     </div>
 
-                    <div className='w-[28%] uppercase md:hover:underline underline-offset-4 decoration-2 text-[var(--darkPurple)] dark:text-[var(--purple)]'>
+                    <div className='w-[25%] uppercase md:hover:underline underline-offset-4 decoration-2 text-[var(--darkPurple)] dark:text-[var(--purple)]'>
                         <LinkEntity entity={slot.f_pool_name} mxAuto />
                     </div>
 
-                    <div className='w-[15%] md:hover:underline underline-offset-4 decoration-2 text-[var(--darkPurple)] dark:text-[var(--purple)]'>
+                    <div className='w-[12%] md:hover:underline underline-offset-4 decoration-2 text-[var(--darkPurple)] dark:text-[var(--purple)]'>
                         <LinkValidator validator={slot.f_val_idx} mxAuto />
                     </div>
 
-                    <div className='w-[15%] md:hover:underline underline-offset-4 decoration-2 text-[var(--darkPurple)] dark:text-[var(--purple)]'>
+                    <div className='w-[12%] md:hover:underline underline-offset-4 decoration-2 text-[var(--darkPurple)] dark:text-[var(--purple)]'>
                         <LinkSlot slot={slot.f_proposer_slot} mxAuto />
                     </div>
 
@@ -111,7 +143,7 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
 
                     <p className='w-[10%] text-center'>{slot.f_attestations}</p>
 
-                    <p className='w-[12%] text-center'>{(slot.f_sync_bits * 100 / 512).toFixed(2)}%</p>
+                    <p className='w-[15%] text-center'>{(slot.f_sync_bits * 100 / 512).toFixed(2)}%</p>
 
                     <p className='w-[10%] text-center'>{slot.f_deposits}</p>
 
@@ -119,7 +151,7 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
 
                     <p className='w-[10%] text-center'>{slot.f_voluntary_exits}</p>
 
-                    <p className='w-[15%] text-center'>{(slot.withdrawals / 10 ** 9).toLocaleString()} ETH</p>
+                    <p className='w-[15%] text-center'>{slot.withdrawals}({(slot.withdrawals / 10 ** 9).toLocaleString()}) ETH</p>
                 </LargeTableRow>
             ))}
         </LargeTable>

--- a/packages/client/components/layouts/Slots.tsx
+++ b/packages/client/components/layouts/Slots.tsx
@@ -67,7 +67,6 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
             <LargeTableHeader text='Proposer' width='12%' />
             <LargeTableHeader text='Slot' width='12%' />
             <LargeTableHeader text='Time' width='10%' />
-            <LargeTableHeader text='Root Hash' width='15%' />
             <LargeTableHeader text='Att' width='10%' tooltipContent={
                     <TooltipResponsive
                         width={220}
@@ -139,8 +138,6 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                         </span>
                     </div>
 
-                    <p className='w-[15%] text-center'>{(slot.f_block) ? getShortAddress(slot.f_block) : "N/A"}</p>
-
                     <p className='w-[10%] text-center'>{(slot?.f_attestations === 0) ? "-" : slot.f_attestations}</p>
 
                     <p className='w-[15%] text-center'>{(slot?.f_attestations === 0) ? '-' : `${(slot.f_sync_bits * 100 / 512).toFixed(2)}%`}</p>
@@ -198,13 +195,6 @@ const Slots = ({ slots, fetchingSlots }: Props) => {
                                         ).toLocaleTimeString('ja-JP')}
                                     </p>
                                 </div>
-                            </div>
-
-                            <div className='flex items-center justify-between'>
-                                <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>
-                                    Root Hash:
-                                </p>
-                                <p>{(slot.f_block) ? getShortAddress(slot.f_block) : "N/A"}</p>
                             </div>
 
                             <div className='flex items-center justify-between'>

--- a/packages/client/pages/epoch/[id].tsx
+++ b/packages/client/pages/epoch/[id].tsx
@@ -270,8 +270,8 @@ const EpochComponent = ({ id, network }: Props) => {
                             tooltipColor='blue'
                             tooltipContent={
                                 <>
-                                    <span>Agg. Rewards: {epoch?.f_att_effective_balance_eth}</span>
-                                    <span>Max. Rewards: {epoch?.f_total_effective_balance_eth}</span>
+                                    <span>Att. Balance: {epoch?.f_att_effective_balance_eth.toLocaleString()} ETH</span>
+                                    <span>Max. Balance: {epoch?.f_total_effective_balance_eth.toLocaleString()} ETH</span>
                                 </>
                             }
                             widthTooltip={220}

--- a/packages/client/pages/epoch/[id].tsx
+++ b/packages/client/pages/epoch/[id].tsx
@@ -278,41 +278,43 @@ const EpochComponent = ({ id, network }: Props) => {
               </div>
            )}
 
-           {id && (Number(id) > 74239 || network !== "mainnet")  && (
-              <div className='flex flex-col'>
-                  <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Voting Participation:</p>
-                  {epoch && epoch.f_epoch === undefined && (
-                      <p className='w-32 uppercase ml-10 mt-2 text-start'>{calculatingText}</p>
-                  )}
-                  <div className='pt-3 py-1 mx-auto md:mx-0'>
-                      {epoch && epoch.f_epoch !== undefined && (
-                          <ProgressSmoothBar
-                              title=''
-                              color='#343434'
-                              backgroundColor='#f5f5f5'
-                              width={300}
-                              percent={epoch.f_att_effective_balance_eth / epoch.f_total_effective_balance_eth || 0}
-                              tooltipColor='blue'
-                              tooltipContent={
-                                  <>
-                                      <span>Att. Balance: {epoch?.f_att_effective_balance_eth.toLocaleString()} ETH</span>
-                                      <span>Act. Balance: {epoch?.f_total_effective_balance_eth.toLocaleString()} ETH</span>
-                                  </>
-                              }
-                              widthTooltip={220}
-                          />
-                      )}
-                  </div>
-              </div>
-              <p className="text-xl font-semibold">Validator Overview</p>
-              <hr className="h-2"></hr>
-              <div className='flex flex-row items-center gap-x-5'>
-                      <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Active Validators:</p>
-                      <p className='text-[var(--black)] dark:text-[var(--white)]'>
-                          {epoch?.f_num_active_vals.toLocaleString()}
-                      </p>
-              </div>
-          )}
+            {id && (Number(id) > 74239 || network !== "mainnet") && (
+                <div>
+                    <div className='flex flex-col'>
+                        <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Voting Participation:</p>
+                        {epoch && epoch.f_epoch === undefined && (
+                            <p className='w-32 uppercase ml-10 mt-2 text-start'>{calculatingText}</p>
+                        )}
+                        <div className='pt-3 py-1 mx-auto md:mx-0'>
+                            {epoch && epoch.f_epoch !== undefined && (
+                                <ProgressSmoothBar
+                                    title=''
+                                    color='#343434'
+                                    backgroundColor='#f5f5f5'
+                                    width={300}
+                                    percent={epoch.f_att_effective_balance_eth / epoch.f_total_effective_balance_eth || 0}
+                                    tooltipColor='blue'
+                                    tooltipContent={
+                                        <>
+                                            <span>Att. Balance: {epoch?.f_att_effective_balance_eth.toLocaleString()} ETH</span>
+                                            <span>Act. Balance: {epoch?.f_total_effective_balance_eth.toLocaleString()} ETH</span>
+                                        </>
+                                    }
+                                    widthTooltip={220}
+                                />
+                            )}
+                        </div>
+                    </div>
+                    <p className="text-xl font-semibold">Validator Overview</p>
+                    <hr className="h-2"></hr>
+                    <div className='flex flex-row items-center gap-x-5'>
+                            <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Active Validators:</p>
+                            <p className='text-[var(--black)] dark:text-[var(--white)]'>
+                                {epoch?.f_num_active_vals.toLocaleString()}
+                            </p>
+                    </div>
+                </div>
+            )}
 
             <div className='flex flex-row items-center gap-x-5'>
                     <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Pending validators:</p>

--- a/packages/client/pages/epoch/[id].tsx
+++ b/packages/client/pages/epoch/[id].tsx
@@ -160,7 +160,8 @@ const EpochComponent = ({ id, network }: Props) => {
             setLoadingSlots(false);
         }
     };
-
+    console.log(id);
+    console.log(epoch);
     // Epoch stats card
     const getContentEpochStats = () => (
         <div
@@ -175,6 +176,21 @@ const EpochComponent = ({ id, network }: Props) => {
                     {new Date(blockGenesis + id * 32 * 12000).toLocaleString('ja-JP')}
                 </p>
             </div>
+
+            <div className='flex flex-row items-center gap-x-5'>
+                    <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Attestations:</p>
+                    <p className='text-[var(--black)] dark:text-[var(--white)]'>
+                        {epoch?.f_num_att.toLocaleString()}
+                    </p>
+            </div>
+
+            <div className='flex flex-row items-center gap-x-5'>
+                <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Withdrawals:</p>
+                <p className='text-[var(--black)] dark:text-[var(--white)]'>
+                    {epoch?.f_withdrawals_num} ({((epoch?.withdrawals ?? 0) / 10 ** 9).toLocaleString()} ETH)
+                </p>
+            </div>
+
 
             <div className='flex flex-col sm:flex-row gap-x-5'>
                 <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Blocks (out of 32):</p>
@@ -271,7 +287,7 @@ const EpochComponent = ({ id, network }: Props) => {
                             tooltipContent={
                                 <>
                                     <span>Att. Balance: {epoch?.f_att_effective_balance_eth.toLocaleString()} ETH</span>
-                                    <span>Max. Balance: {epoch?.f_total_effective_balance_eth.toLocaleString()} ETH</span>
+                                    <span>Act. Balance: {epoch?.f_total_effective_balance_eth.toLocaleString()} ETH</span>
                                 </>
                             }
                             widthTooltip={220}
@@ -281,10 +297,38 @@ const EpochComponent = ({ id, network }: Props) => {
             </div>
 
             <div className='flex flex-row items-center gap-x-5'>
-                <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Withdrawals:</p>
-                <p className='text-[var(--black)] dark:text-[var(--white)]'>
-                    {((epoch?.withdrawals ?? 0) / 10 ** 9).toLocaleString()} ETH
-                </p>
+                    <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Validators:</p>
+                    <p className='text-[var(--black)] dark:text-[var(--white)]'>
+                        {epoch?.f_num_active_vals.toLocaleString()}
+                    </p>
+            </div>
+
+            <div className='flex flex-row items-center gap-x-5'>
+                    <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Pending validators:</p>
+                    <p className='text-[var(--black)] dark:text-[var(--white)]'>
+                        {epoch?.f_num_in_activation_vals.toLocaleString()}
+                    </p>
+            </div>
+
+            <div className='flex flex-row items-center gap-x-5'>
+                    <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Slashed Validators:</p>
+                    <p className='text-[var(--black)] dark:text-[var(--white)]'>
+                        {epoch?.f_num_slashed_vals.toLocaleString()}
+                    </p>
+            </div>
+
+            <div className='flex flex-row items-center gap-x-5'>
+                    <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Exited Validators:</p>
+                    <p className='text-[var(--black)] dark:text-[var(--white)]'>
+                        {epoch?.f_num_exited_vals.toLocaleString()}
+                    </p>
+            </div>
+
+            <div className='flex flex-row items-center gap-x-5'>
+                    <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Avg. Validator Balance:</p>
+                    <p className='text-[var(--black)] dark:text-[var(--white)]'>
+                        {(epoch.f_total_balance_eth / epoch?.f_num_active_vals).toFixed(2)} ETH
+                    </p>
             </div>
         </div>
     );

--- a/packages/client/pages/epoch/[id].tsx
+++ b/packages/client/pages/epoch/[id].tsx
@@ -235,7 +235,7 @@ const EpochComponent = ({ id, network }: Props) => {
                             tooltipContent={
                                 <>
                                     <span>Missing Source: {epoch.f_missing_source?.toLocaleString()}</span>
-                                    <span>Attestations: {epoch.f_num_att_vals?.toLocaleString()}</span>
+                                    <span>Attesting Validators: {epoch.f_num_att_vals?.toLocaleString()}</span>
                                 </>
                             }
                             widthTooltip={220}
@@ -251,7 +251,7 @@ const EpochComponent = ({ id, network }: Props) => {
                             tooltipContent={
                                 <>
                                     <span>Missing Target: {epoch.f_missing_target?.toLocaleString()}</span>
-                                    <span>Attestations: {epoch.f_num_att_vals?.toLocaleString()}</span>
+                                    <span>Attesting Validators: {epoch.f_num_att_vals?.toLocaleString()}</span>
                                 </>
                             }
                             widthTooltip={220}
@@ -267,7 +267,7 @@ const EpochComponent = ({ id, network }: Props) => {
                             tooltipContent={
                                 <>
                                     <span>Missing Head: {epoch.f_missing_head?.toLocaleString()}</span>
-                                    <span>Attestations: {epoch.f_num_att_vals?.toLocaleString()}</span>
+                                    <span>Attesting Validators: {epoch.f_num_att_vals?.toLocaleString()}</span>
                                 </>
                             }
                             widthTooltip={220}

--- a/packages/client/pages/epoch/[id].tsx
+++ b/packages/client/pages/epoch/[id].tsx
@@ -301,9 +301,10 @@ const EpochComponent = ({ id, network }: Props) => {
                     )}
                 </div>
             </div>
-
+            <p className="text-xl font-semibold">Validator Overview</p>
+            <hr className="h-2"></hr>
             <div className='flex flex-row items-center gap-x-5'>
-                    <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Validators:</p>
+                    <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Active Validators:</p>
                     <p className='text-[var(--black)] dark:text-[var(--white)]'>
                         {epoch?.f_num_active_vals.toLocaleString()}
                     </p>

--- a/packages/client/pages/epoch/[id].tsx
+++ b/packages/client/pages/epoch/[id].tsx
@@ -160,8 +160,7 @@ const EpochComponent = ({ id, network }: Props) => {
             setLoadingSlots(false);
         }
     };
-    console.log(id);
-    console.log(epoch);
+
     // Epoch stats card
     const getContentEpochStats = () => (
         <div
@@ -334,7 +333,7 @@ const EpochComponent = ({ id, network }: Props) => {
             <div className='flex flex-row items-center gap-x-5'>
                     <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Avg. Validator Balance:</p>
                     <p className='text-[var(--black)] dark:text-[var(--white)]'>
-                        {(epoch.f_total_balance_eth / epoch?.f_num_active_vals).toFixed(2)} ETH
+                        {((epoch?.f_total_balance_eth ?? 0) / (epoch?.f_num_active_vals ?? 0)).toFixed(2)} ETH
                     </p>
             </div>
         </div>

--- a/packages/client/pages/epoch/[id].tsx
+++ b/packages/client/pages/epoch/[id].tsx
@@ -185,6 +185,13 @@ const EpochComponent = ({ id, network }: Props) => {
             </div>
 
             <div className='flex flex-row items-center gap-x-5'>
+                    <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Deposits:</p>
+                    <p className='text-[var(--black)] dark:text-[var(--white)]'>
+                        {epoch?.f_deposits_num.toLocaleString()}
+                    </p>
+            </div>
+
+            <div className='flex flex-row items-center gap-x-5'>
                 <p className='w-40 sm:w-60 text-[var(--black)] dark:text-[var(--white)]'>Withdrawals:</p>
                 <p className='text-[var(--black)] dark:text-[var(--white)]'>
                     {epoch?.f_withdrawals_num} ({((epoch?.withdrawals ?? 0) / 10 ** 9).toLocaleString()} ETH)

--- a/packages/client/types/index.ts
+++ b/packages/client/types/index.ts
@@ -87,6 +87,7 @@ export type Slot = {
     f_voluntary_exits: number;
     f_epoch?: number;
     withdrawals: number;
+    num_withdrawals: number;
 };
 
 export type Withdrawal = {

--- a/packages/client/types/index.ts
+++ b/packages/client/types/index.ts
@@ -78,7 +78,6 @@ export type Slot = {
     f_pool_name: string;
     f_val_idx: number;
     f_proposed: boolean;
-    f_block: string;
     f_attestations: number;
     f_sync_bits: number;
     f_deposits: number;

--- a/packages/client/types/index.ts
+++ b/packages/client/types/index.ts
@@ -1,6 +1,7 @@
 export type Epoch = {
     f_epoch: number;
     f_slot: number;
+    f_num_att: number;
     f_num_att_vals: number;
     f_num_active_vals: number;
     f_att_effective_balance_eth: number;
@@ -8,6 +9,14 @@ export type Epoch = {
     f_missing_source: number;
     f_missing_target: number;
     f_missing_head: number;
+    f_withdrawals_num: number;
+    f_deposits_num: number;
+    f_new_proposer_slashings: number;
+    f_new_attester_slashings: number;
+    f_num_slashed_vals: number;
+    f_num_exited_vals: number;
+    f_num_in_activation_vals: number;
+    f_total_balance_eth: number;
     proposed_blocks: Array<number>;
     withdrawals?: number;
 };
@@ -69,6 +78,14 @@ export type Slot = {
     f_pool_name: string;
     f_val_idx: number;
     f_proposed: boolean;
+    f_block: string;
+    f_attestations: number;
+    f_sync_bits: number;
+    f_deposits: number;
+    f_attester_slashings: number;
+    f_proposer_slashings: number;
+    f_voluntary_exits: number;
+    "pd.f_val_idx": number;
     f_epoch?: number;
     withdrawals: number;
 };

--- a/packages/client/types/index.ts
+++ b/packages/client/types/index.ts
@@ -85,7 +85,6 @@ export type Slot = {
     f_attester_slashings: number;
     f_proposer_slashings: number;
     f_voluntary_exits: number;
-    "pd.f_val_idx": number;
     f_epoch?: number;
     withdrawals: number;
 };

--- a/packages/server/controllers/epochs.ts
+++ b/packages/server/controllers/epochs.ts
@@ -16,13 +16,15 @@ export const getEpochsStatistics = async (req: Request, res: Response) => {
                         SELECT
                             f_epoch,
                             f_slot,
+                            f_num_att,
                             f_num_att_vals,
                             f_num_active_vals,
                             f_att_effective_balance_eth,
                             f_total_effective_balance_eth,
                             f_missing_source,
                             f_missing_target,
-                            f_missing_head
+                            f_missing_head,
+                            f_withdrawals_num
                         FROM
                             t_epoch_metrics_summary
                         ORDER BY
@@ -116,14 +118,7 @@ export const getEpochById = async (req: Request, res: Response) => {
                             f_total_effective_balance_eth,
                             f_missing_source,
                             f_missing_target,
-                            f_missing_head,
-                            f_num_att,
-                            f_num_slashed_vals,
-                            f_num_exited_vals,
-                            f_num_active_vals,
-                            f_num_in_activation_vals,
-                            f_total_balance_eth,
-                            f_withdrawals_num,
+                            f_missing_head
                         FROM
                             t_epoch_metrics_summary
                         WHERE

--- a/packages/server/controllers/epochs.ts
+++ b/packages/server/controllers/epochs.ts
@@ -24,7 +24,10 @@ export const getEpochsStatistics = async (req: Request, res: Response) => {
                             f_missing_source,
                             f_missing_target,
                             f_missing_head,
-                            f_withdrawals_num
+                            f_withdrawals_num,
+                            f_deposits_num,
+                            f_new_proposer_slashings,
+                            f_new_attester_slashings
                         FROM
                             t_epoch_metrics_summary
                         ORDER BY
@@ -112,13 +115,22 @@ export const getEpochById = async (req: Request, res: Response) => {
                         SELECT
                             f_epoch,
                             f_slot,
+                            f_num_att,
+                            f_deposits_num,
+                            f_withdrawals_num,
                             f_num_att_vals,
                             f_num_active_vals,
                             f_att_effective_balance_eth,
                             f_total_effective_balance_eth,
                             f_missing_source,
                             f_missing_target,
-                            f_missing_head
+                            f_missing_head,
+                            f_num_slashed_vals,
+                            f_num_active_vals,
+                            f_num_exited_vals,
+                            f_num_in_activation_vals,
+                            f_total_balance_eth
+
                         FROM
                             t_epoch_metrics_summary
                         WHERE
@@ -183,11 +195,22 @@ export const getSlotsByEpoch = async (req: Request, res: Response) => {
                             pd.f_val_idx,
                             pd.f_proposer_slot,
                             pd.f_proposed,
-                            pk.f_pool_name
+                            pk.f_pool_name,
+                            hd.f_block,
+                            bm.f_attestations,
+                            bm.f_sync_bits,
+                            bm.f_deposits,
+                            bm.f_attester_slashings,
+                            bm.f_proposer_slashings,
+                            bm.f_voluntary_exits
                         FROM
                             t_proposer_duties pd
                         LEFT OUTER JOIN
                             t_eth2_pubkeys pk ON pd.f_val_idx = pk.f_val_idx
+                        LEFT OUTER JOIN
+                            t_head_events hd ON CAST(pd.f_proposer_slot AS String) = CAST(hd.f_slot AS String)
+                        LEFT OUTER JOIN
+                            t_block_metrics bm ON CAST(pd.f_proposer_slot AS String) = CAST(bm.f_slot AS String)
                         WHERE
                             CAST((pd.f_proposer_slot / 32) AS UInt64) = ${id}
                         ORDER BY

--- a/packages/server/controllers/epochs.ts
+++ b/packages/server/controllers/epochs.ts
@@ -192,17 +192,17 @@ export const getSlotsByEpoch = async (req: Request, res: Response) => {
             clickhouseClient.query({
                 query: `
                         SELECT
-                            pd.f_val_idx,
-                            pd.f_proposer_slot,
-                            pd.f_proposed,
-                            pk.f_pool_name,
-                            hd.f_block,
-                            bm.f_attestations,
-                            bm.f_sync_bits,
-                            bm.f_deposits,
-                            bm.f_attester_slashings,
-                            bm.f_proposer_slashings,
-                            bm.f_voluntary_exits
+                            pd.f_val_idx AS f_val_idx,
+                            pd.f_proposer_slot AS f_proposer_slot,
+                            pd.f_proposed AS f_proposed,
+                            pk.f_pool_name AS f_pool_name,
+                            hd.f_block AS f_block,
+                            bm.f_attestations AS f_attestations,
+                            bm.f_sync_bits AS f_sync_bits,
+                            bm.f_deposits AS f_deposits,
+                            bm.f_attester_slashings AS f_attester_slashings,
+                            bm.f_proposer_slashings AS f_proposer_slashings,
+                            bm.f_voluntary_exits AS f_voluntary_exits
                         FROM
                             t_proposer_duties pd
                         LEFT OUTER JOIN

--- a/packages/server/controllers/epochs.ts
+++ b/packages/server/controllers/epochs.ts
@@ -116,7 +116,14 @@ export const getEpochById = async (req: Request, res: Response) => {
                             f_total_effective_balance_eth,
                             f_missing_source,
                             f_missing_target,
-                            f_missing_head
+                            f_missing_head,
+                            f_num_att,
+                            f_num_slashed_vals,
+                            f_num_exited_vals,
+                            f_num_active_vals,
+                            f_num_in_activation_vals,
+                            f_total_balance_eth,
+                            f_withdrawals_num,
                         FROM
                             t_epoch_metrics_summary
                         WHERE

--- a/packages/server/controllers/epochs.ts
+++ b/packages/server/controllers/epochs.ts
@@ -196,7 +196,6 @@ export const getSlotsByEpoch = async (req: Request, res: Response) => {
                             pd.f_proposer_slot AS f_proposer_slot,
                             pd.f_proposed AS f_proposed,
                             pk.f_pool_name AS f_pool_name,
-                            hd.f_block AS f_block,
                             bm.f_attestations AS f_attestations,
                             bm.f_sync_bits AS f_sync_bits,
                             bm.f_deposits AS f_deposits,
@@ -208,9 +207,7 @@ export const getSlotsByEpoch = async (req: Request, res: Response) => {
                         LEFT OUTER JOIN
                             t_eth2_pubkeys pk ON pd.f_val_idx = pk.f_val_idx
                         LEFT OUTER JOIN
-                            t_head_events hd ON CAST(pd.f_proposer_slot AS String) = CAST(hd.f_slot AS String)
-                        LEFT OUTER JOIN
-                            t_block_metrics bm ON CAST(pd.f_proposer_slot AS String) = CAST(bm.f_slot AS String)
+                            t_block_metrics bm ON pd.f_proposer_slot = bm.f_slot
                         WHERE
                             CAST((pd.f_proposer_slot / 32) AS UInt64) = ${id}
                         ORDER BY

--- a/packages/server/controllers/slots.ts
+++ b/packages/server/controllers/slots.ts
@@ -79,37 +79,35 @@ export const getSlots = async (req: Request, res: Response) => {
             chClient.query({
                 query: `
                         SELECT
-                            pd.f_proposer_slot AS f_proposer_slot,
-                            pd.f_val_idx AS f_val_idx,
-                            pd.f_proposed AS f_proposed,
-                            pk.f_pool_name AS f_pool_name,
+                            bm.f_slot AS f_proposer_slot,
+                            bm.f_proposer_index AS f_val_idx,
+                            bm.f_proposed AS f_proposed,
                             bm.f_attestations AS f_attestations,
                             bm.f_sync_bits AS f_sync_bits,
                             bm.f_deposits AS f_deposits,
                             bm.f_attester_slashings AS f_attester_slashings,
                             bm.f_proposer_slashings AS f_proposer_slashings,
                             bm.f_voluntary_exits AS f_voluntary_exits,
+                            pk.f_pool_name AS f_pool_name,
                             COALESCE(SUM(w.f_amount), 0) AS withdrawals,
                             COALESCE(COUNT(w.f_slot), 0) AS num_withdrawals
                         FROM
-                            t_proposer_duties pd
+                            t_block_metrics bm
                         LEFT OUTER JOIN
-                            t_eth2_pubkeys pk ON pd.f_val_idx = pk.f_val_idx
+                            t_eth2_pubkeys pk ON bm.f_proposer_index = pk.f_val_idx
                         LEFT OUTER JOIN
-                            t_withdrawals w ON pd.f_proposer_slot = w.f_slot
+                            t_withdrawals w ON bm.f_slot = w.f_slot
                         LEFT OUTER JOIN
-                            t_orphans o ON pd.f_proposer_slot = o.f_slot
-                        LEFT OUTER JOIN
-                            t_block_metrics bm ON pd.f_proposer_slot = bm.f_slot
+                            t_orphans o ON bm.f_slot = o.f_slot
                         CROSS JOIN
                             t_genesis g
                         LEFT OUTER JOIN
-                            t_slot_client_guesses scg ON pd.f_proposer_slot = scg.f_slot
+                            t_slot_client_guesses scg ON bm.f_slot = scg.f_slot
                         ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
                         GROUP BY
-                            pd.f_proposer_slot, pd.f_val_idx, pd.f_proposed, pk.f_pool_name, bm.f_attestations, bm.f_sync_bits, bm.f_deposits, bm.f_attester_slashings, bm.f_proposer_slashings, bm.f_voluntary_exits
+                            bm.f_slot, bm.f_proposer_index, bm.f_proposed, pk.f_pool_name, bm.f_attestations, bm.f_sync_bits, bm.f_deposits, bm.f_attester_slashings, bm.f_proposer_slashings, bm.f_voluntary_exits
                         ORDER BY
-                            pd.f_proposer_slot DESC
+                            bm.f_slot DESC
                         LIMIT ${Number(limit)}
                         OFFSET ${skip}
                     `,

--- a/packages/server/controllers/slots.ts
+++ b/packages/server/controllers/slots.ts
@@ -83,6 +83,13 @@ export const getSlots = async (req: Request, res: Response) => {
                             pd.f_val_idx AS f_val_idx,
                             pd.f_proposed AS f_proposed,
                             pk.f_pool_name AS f_pool_name,
+                            hd.f_block AS f_block,
+                            bm.f_attestations AS f_attestations,
+                            bm.f_sync_bits AS f_sync_bits,
+                            bm.f_deposits AS f_deposits,
+                            bm.f_attester_slashings AS f_attester_slashings,
+                            bm.f_proposer_slashings AS f_proposer_slashings,
+                            bm.f_voluntary_exits AS f_voluntary_exits,
                             COALESCE(SUM(w.f_amount), 0) AS withdrawals
                         FROM
                             t_proposer_duties pd
@@ -92,13 +99,17 @@ export const getSlots = async (req: Request, res: Response) => {
                             t_withdrawals w ON pd.f_proposer_slot = w.f_slot
                         LEFT OUTER JOIN
                             t_orphans o ON pd.f_proposer_slot = o.f_slot
+                        LEFT OUTER JOIN
+                            t_head_events hd ON CAST(pd.f_proposer_slot AS String) = CAST(hd.f_slot AS String)
+                        LEFT OUTER JOIN
+                            t_block_metrics bm ON CAST(pd.f_proposer_slot AS String) = CAST(bm.f_slot AS String)
                         CROSS JOIN
                             t_genesis g
                         LEFT OUTER JOIN
                             t_slot_client_guesses scg ON pd.f_proposer_slot = scg.f_slot
                         ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
                         GROUP BY
-                            pd.f_proposer_slot, pd.f_val_idx, pd.f_proposed, pk.f_pool_name
+                            pd.f_proposer_slot, pd.f_val_idx, pd.f_proposed, pk.f_pool_name, hd.f_block, bm.f_attestations, bm.f_sync_bits, bm.f_deposits, bm.f_attester_slashings, bm.f_proposer_slashings, bm.f_voluntary_exits
                         ORDER BY
                             pd.f_proposer_slot DESC
                         LIMIT ${Number(limit)}

--- a/packages/server/controllers/slots.ts
+++ b/packages/server/controllers/slots.ts
@@ -90,7 +90,8 @@ export const getSlots = async (req: Request, res: Response) => {
                             bm.f_attester_slashings AS f_attester_slashings,
                             bm.f_proposer_slashings AS f_proposer_slashings,
                             bm.f_voluntary_exits AS f_voluntary_exits,
-                            COALESCE(SUM(w.f_amount), 0) AS withdrawals
+                            COALESCE(SUM(w.f_amount), 0) AS withdrawals,
+                            COALESCE(COUNT(w.f_slot), 0) AS num_withdrawals
                         FROM
                             t_proposer_duties pd
                         LEFT OUTER JOIN

--- a/packages/server/controllers/slots.ts
+++ b/packages/server/controllers/slots.ts
@@ -83,7 +83,6 @@ export const getSlots = async (req: Request, res: Response) => {
                             pd.f_val_idx AS f_val_idx,
                             pd.f_proposed AS f_proposed,
                             pk.f_pool_name AS f_pool_name,
-                            hd.f_block AS f_block,
                             bm.f_attestations AS f_attestations,
                             bm.f_sync_bits AS f_sync_bits,
                             bm.f_deposits AS f_deposits,
@@ -101,16 +100,14 @@ export const getSlots = async (req: Request, res: Response) => {
                         LEFT OUTER JOIN
                             t_orphans o ON pd.f_proposer_slot = o.f_slot
                         LEFT OUTER JOIN
-                            t_head_events hd ON CAST(pd.f_proposer_slot AS String) = CAST(hd.f_slot AS String)
-                        LEFT OUTER JOIN
-                            t_block_metrics bm ON CAST(pd.f_proposer_slot AS String) = CAST(bm.f_slot AS String)
+                            t_block_metrics bm ON pd.f_proposer_slot = bm.f_slot
                         CROSS JOIN
                             t_genesis g
                         LEFT OUTER JOIN
                             t_slot_client_guesses scg ON pd.f_proposer_slot = scg.f_slot
                         ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
                         GROUP BY
-                            pd.f_proposer_slot, pd.f_val_idx, pd.f_proposed, pk.f_pool_name, hd.f_block, bm.f_attestations, bm.f_sync_bits, bm.f_deposits, bm.f_attester_slashings, bm.f_proposer_slashings, bm.f_voluntary_exits
+                            pd.f_proposer_slot, pd.f_val_idx, pd.f_proposed, pk.f_pool_name, bm.f_attestations, bm.f_sync_bits, bm.f_deposits, bm.f_attester_slashings, bm.f_proposer_slashings, bm.f_voluntary_exits
                         ORDER BY
                             pd.f_proposer_slot DESC
                         LIMIT ${Number(limit)}


### PR DESCRIPTION
## DESCRIPTION

Provide more details about the epochs in the epochs statistics page and the epoch page.
The information added in the epochs statistics page are the following ones:
-  The number of attestations
- The number of withdrawals
- Number of deposits
- Number of slashings (proposer/attester)
The information added in the epoch page are the following ones:
- Number of deposits
- Number of attestations
- Sync participation
- Number of withdrawals with the amount of ETH
- Validators overview
- Information about the slots
#### Results:
Epochs statistics page:
![image](https://github.com/user-attachments/assets/b2f4da56-2a54-4d8a-ba57-8d34538e4c3e)

Epoch information:
![image](https://github.com/user-attachments/assets/31972679-0107-4d75-b42e-5f155be3ab38)

Slots information:
![image](https://github.com/user-attachments/assets/5a4cf7cc-3770-4bda-b6fc-ec156e9309b5)
