### PR TITLE
[add] slashed validator data in the validator page

### DIFF
--- a/packages/client/pages/validator/[id].tsx
+++ b/packages/client/pages/validator/[id].tsx
@@ -28,7 +28,12 @@ import { LargeTable, LargeTableHeader, LargeTableRow, SmallTable, SmallTableCard
 import ShareMenu from '../../components/ui/ShareMenu';
 
 // Types
-import { Validator, Slot, Withdrawal } from '../../types';
+import { Validator, Slot, Withdrawal, SlashedVal } from '../../types';
+import LinkValidator from '../../components/ui/LinkValidator';
+import { getShortAddress } from '../../helpers/addressHelper';
+import { getTimeAgo } from '../../helpers/timeHelper';
+import TooltipContainer from '../../components/ui/TooltipContainer';
+import TooltipResponsive from '../../components/ui/TooltipResponsive';
 
 // Props
 interface Props {
@@ -66,12 +71,14 @@ const ValidatorComponent = ({ id, network }: Props) => {
     const [validatorWeek, setValidatorWeek] = useState<Validator | null>(null);
     const [proposedBlocks, setProposedBlocks] = useState<Slot[]>([]);
     const [withdrawals, setWithdrawals] = useState<Withdrawal[]>([]);
+    const [slashedVals, setSlashedValidator] = useState<SlashedVal[]>([]);
     const [showInfoBox, setShowInfoBox] = useState(false);
     const [tabPageIndex, setTabPageIndex] = useState(0);
     const [tabPageIndexValidatorPerformance, setTabPageIndexValidatorPerformance] = useState(0);
     const [loadingValidator, setLoadingValidator] = useState(true);
     const [loadingProposedBlocks, setLoadingProposedBlocks] = useState(true);
     const [loadingWithdrawals, setLoadingWithdrawals] = useState(true);
+    const [loadingSlashedValidator, setLoadingSlashedValidator] = useState(true);
     const [blockGenesis, setBlockGenesis] = useState(0);
 
     // UseEffect
@@ -81,6 +88,7 @@ const ValidatorComponent = ({ id, network }: Props) => {
             getValidator();
             getProposedBlocks();
             getWithdrawals();
+            getSlashedValidatorById();
         }
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -171,6 +179,24 @@ const ValidatorComponent = ({ id, network }: Props) => {
             console.log(error);
         } finally {
             setLoadingWithdrawals(false);
+        }
+    };
+
+    const getSlashedValidatorById = async () => {
+        try {
+            setLoadingSlashedValidator(true);
+
+            const response = await axiosClient.get(`/api/slashedValidators/${id}`, {
+                params: {
+                    network,
+                },
+            });
+
+            setSlashedValidator(response.data.slashedValidatorResult);
+        } catch (error) {
+            console.log(error);
+        } finally {
+            setLoadingSlashedValidator(false);
         }
     };
 
@@ -299,6 +325,16 @@ const ValidatorComponent = ({ id, network }: Props) => {
                     );
                 } else {
                     return isLargeView ? getWithdrawalsLargeView() : getWithdrawalsSmallView();
+                }
+            case 2:
+                if (loadingSlashedValidator) {
+                    return (
+                        <div className='mt-6'>
+                            <Loader />
+                        </div>
+                    );
+                } else {
+                    return isLargeView ? getSlashedValidatorsLargeView() : getSlashedValidatorSmallView();
                 }
         }
     };
@@ -558,6 +594,102 @@ const ValidatorComponent = ({ id, network }: Props) => {
         </SmallTable>
     );
 
+    const getSlashedValidatorsLargeView = () => (
+        <LargeTable minWidth={700} fullWidth noRowsText='No Slashed Validators' fetchingRows={loadingSlashedValidator}>
+            <LargeTableHeader text='Slot' />
+            <LargeTableHeader text='Time' />
+            <LargeTableHeader text='Reason' />
+            <LargeTableHeader text='Slot' />
+            <LargeTableHeader text='Epoch' />
+
+            {slashedVals.map((slashedVal, idx) => (
+                <LargeTableRow key={idx}>
+                    <div className="w-[20%]  flex justify-center items-center ">
+                        <LinkValidator validator={slashedVal.f_slashed_validator_index} />
+                    </div>
+                    
+                    <div className='w-[20%]'>
+                        <TooltipContainer>
+                            <div>
+                                <p>{getTimeAgo(blockGenesis + slashedVal.f_slot * 12000)}</p>
+                            </div>
+                            <TooltipResponsive
+                            width={120}
+                            content={
+                                <>
+                                    <p>{new Date(blockGenesis + slashedVal.f_slot * 12000).toLocaleDateString('ja-JP')}</p>
+                                    <p>{new Date(blockGenesis + slashedVal.f_slot * 12000).toLocaleTimeString('ja-JP')}</p>
+                                </>
+                            }
+                            top='34px'
+                            />
+                        </TooltipContainer>
+                    </div>
+
+                    <p className='w-[20%]'>
+                        {slashedVal.f_slashing_reason.split(/(?=[A-Z])/).join(" ")}
+                    </p>
+
+                    <div className='w-[20%]'>
+                        <LinkSlot slot={slashedVal.f_slot} mxAuto />
+                    </div>
+                    
+                    <div className='w-[20%]'>
+                        <LinkEpoch epoch={slashedVal.f_epoch} mxAuto />
+                    </div>
+                </LargeTableRow>
+            ))}
+        </LargeTable>
+    );
+
+    // Slashed Validators Small View
+    const getSlashedValidatorSmallView = () => (
+        <SmallTable fullWidth noRowsText='No Slashed Validators' fetchingRows={loadingSlashedValidator}>
+            {slashedVals.map((slashedVal, idx) => (
+                <SmallTableCard key={idx}>
+
+
+
+                    <div className='flex w-full items-center justify-between'>
+                        <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Time:</p>
+                        <div className='flex flex-col text-end'>
+                            <TooltipContainer>
+                                <div>
+                                    <p>{getTimeAgo(blockGenesis + slashedVal.f_slot * 12000)}</p>
+                                </div>
+                                <TooltipResponsive
+                                width={120}
+                                content={
+                                    <>
+                                        <p>{new Date(blockGenesis + slashedVal.f_slot * 12000).toLocaleDateString('ja-JP')}</p>
+                                        <p>{new Date(blockGenesis + slashedVal.f_slot * 12000).toLocaleTimeString('ja-JP')}</p>
+                                    </>
+                                }
+                                top='34px'
+                                />
+                            </TooltipContainer>
+                        </div>
+                    </div>
+
+                    <div className='flex w-full items-center justify-between'>
+                        <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Reason:</p>
+                        <p>{slashedVal.f_slashing_reason.split(/(?=[A-Z])/).join(" ")}</p>
+                    </div>
+
+                    <div className='flex w-full items-center justify-between'>
+                        <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Slot:</p>
+                        <LinkSlot slot={slashedVal.f_slot} />
+                    </div>
+
+                    <div className='flex w-full items-center justify-between'>
+                        <p className='font-semibold text-[var(--darkGray)] dark:text-[var(--white)]'>Epoch:</p>
+                        <LinkEpoch epoch={slashedVal.f_epoch} />
+                    </div>
+                </SmallTableCard>
+            ))}
+        </SmallTable>
+    );
+
     //OVERVIEW PAGE
     //Overview validator page
     return (
@@ -591,6 +723,11 @@ const ValidatorComponent = ({ id, network }: Props) => {
                             header='Withdrawals'
                             isSelected={tabPageIndex === 1}
                             onClick={() => setTabPageIndex(1)}
+                        />
+                        <TabHeader
+                            header='Slashings'
+                            isSelected={tabPageIndex === 2}
+                            onClick={() => setTabPageIndex(2)}
                         />
                     </div>
 

--- a/packages/server/controllers/slashedValidators.ts
+++ b/packages/server/controllers/slashedValidators.ts
@@ -58,3 +58,42 @@ export const getSlashedVals = async (req: Request, res: Response) => {
         });
     }
 };
+
+export const getSlashedValsById = async (req: Request, res: Response) => {
+    try {
+        const { id } = req.params;
+        const { network } = req.query;
+
+        const clickhouseClient = clickhouseClients[network as string];
+
+        const [slashedValidatorResultSet] = await Promise.all([
+            clickhouseClient.query({
+                query: `
+                        SELECT
+                            f_slashed_validator_index,
+                            f_slashing_reason,
+                            f_slot,
+                            f_epoch,
+                        FROM
+                            t_slashings
+                        WHERE
+                            f_slashed_by_validator_index = ${id}
+                        ORDER BY
+                            f_epoch DESC
+                    `,
+                format: 'JSONEachRow',
+            })
+        ]);
+
+        const slashedValidatorResult: any[] = await slashedValidatorResultSet.json();
+
+        res.json({
+            slashedValidatorResult,
+        });
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({
+            msg: 'An error occurred on the server',
+        });
+    }
+};

--- a/packages/server/routes/slashedValidators.ts
+++ b/packages/server/routes/slashedValidators.ts
@@ -1,8 +1,11 @@
 import { Router } from 'express';
-import { check, query } from 'express-validator';
+import { check, checkSchema, query } from 'express-validator';
+
+import { checkFields } from '../middlewares/check-fields';
 
 import {
     getSlashedVals,
+    getSlashedValsById
 } from '../controllers/slashedValidators';
 
 import { existsNetwork } from '../helpers/network-validator';
@@ -12,6 +15,14 @@ const router = Router();
 router.get('/', [
     query('network').not().isEmpty(),
     query('network').custom(existsNetwork),
+    checkFields
 ], getSlashedVals);
+
+router.get('/:id', [
+    check('id').isInt({ min: 0, max: 2147483647 }),
+    query('network').not().isEmpty(),
+    query('network').custom(existsNetwork),
+    checkFields,
+], getSlashedValsById);
 
 export default router;


### PR DESCRIPTION
## Description

Added the slashed validators information of each validator. The provided information are the following one:
- The age of the slashed validator
- The reason of the slashing
- The slot in which it occurred
- The epoch in which it occured

#### Result:
![image](https://github.com/user-attachments/assets/1fa9d256-a14e-4e78-8328-c5b8d937a2a6)
