### PR TITLE
[feat] Group CSM Operators in Entities page

### DIFF
--- a/packages/client/components/ui/EntityCard.tsx
+++ b/packages/client/components/ui/EntityCard.tsx
@@ -12,12 +12,21 @@ type Props = {
     pool: string;
 };
 
+function poolRoute(pool: string) {
+    const newName = pool.replace(' ', '-').toLocaleLowerCase();
+    if (pool !== 'Lido CSM') {
+        return '/entities/' + newName;
+    }
+
+    return newName;
+}
+
 const EntityCard = ({ activeValidators, pool }: Props) => {
     // Theme Mode Context
     const { themeMode } = useContext(ThemeModeContext) ?? {};
 
     return (
-        <NetworkLink href={`/entities/${pool.toLocaleLowerCase()}`}>
+        <NetworkLink href={`${poolRoute(pool)}`}>
             <div
                 className='flex md:flex-row flex-col h-[150px] md:h-[100px] bg-[var(--bgFairLightMode)] md:hover:bg-[var(--bgStrongLightMode)] transition md:justify-start items-center justify-center py-4 px-2 border-2 gap-2 rounded-md text-[var(--black)] dark:text-[var(--white)]'
                 style={{

--- a/packages/client/pages/entities.tsx
+++ b/packages/client/pages/entities.tsx
@@ -51,31 +51,10 @@ const Entities = () => {
                     network,
                 },
             });
-            
-            const operatorResponse = await axiosClient.get('/api/csm-operators', {
-                params: {
-                    network,
-                },
-            });
-            
-            const fetchedEntities = entityResponse.data.entities.toSorted(
-                (a: Entity, b: Entity) => Number(b.act_number_validators) - Number(a.act_number_validators)
-            );
 
-            setEntities(prevEntities => {
-                const updatedEntities: Entity[] = [...prevEntities, ...fetchedEntities];
-            
-                if (!updatedEntities.some(entity => entity.f_pool_name === 'Lido CSM')) {
-                    updatedEntities.push({
-                        f_pool_name: 'Lido CSM',
-                        act_number_validators: operatorResponse.data.operatorsValidator.reduce((sum : number, operator: Entity) => sum + Number(operator.act_number_validators), 0),
-                    });
-                }
-            
-                return updatedEntities.sort(
-                    (a: Entity, b: Entity) => Number(b.act_number_validators) - Number(a.act_number_validators)
-                );
-            });
+            setEntities(entityResponse.data.entities.toSorted(
+                (a: Entity, b: Entity) => Number(b.act_number_validators) - Number(a.act_number_validators)
+            ));
 
         } catch (error) {
             console.log(error);

--- a/packages/client/pages/entities.tsx
+++ b/packages/client/pages/entities.tsx
@@ -63,7 +63,7 @@ const Entities = () => {
             );
 
             setEntities(prevEntities => {
-                const updatedEntities = [...prevEntities, ...fetchedEntities];
+                const updatedEntities: Entity[] = [...prevEntities, ...fetchedEntities];
             
                 if (!updatedEntities.some(entity => entity.f_pool_name === 'Lido CSM')) {
                     updatedEntities.push({
@@ -73,7 +73,7 @@ const Entities = () => {
                 }
             
                 return updatedEntities.toSorted(
-                    (a, b) => Number(b.act_number_validators) - Number(a.act_number_validators)
+                    (a: Entity, b: Entity) => Number(b.act_number_validators) - Number(a.act_number_validators)
                 );
             });
 

--- a/packages/client/pages/entities.tsx
+++ b/packages/client/pages/entities.tsx
@@ -72,7 +72,7 @@ const Entities = () => {
                     });
                 }
             
-                return updatedEntities.toSorted(
+                return updatedEntities.sort(
                     (a: Entity, b: Entity) => Number(b.act_number_validators) - Number(a.act_number_validators)
                 );
             });

--- a/packages/server/controllers/entities.ts
+++ b/packages/server/controllers/entities.ts
@@ -104,6 +104,18 @@ export const getEntities = async (req: Request, res: Response) => {
                         WHERE
                             NOT (pk.f_pool_name LIKE 'csm_%_lido')
                         GROUP BY pk.f_pool_name
+
+                        UNION ALL
+
+                        SELECT
+                            COUNT(CASE vls.f_status WHEN 1 THEN 1 ELSE null END) AS act_number_validators,
+                            'Lido CSM' AS f_pool_name
+                        FROM
+                            t_validator_last_status vls
+                        LEFT OUTER JOIN
+                            t_eth2_pubkeys pk ON (vls.f_val_idx = pk.f_val_idx)
+                        WHERE
+                            pk.f_pool_name LIKE 'csm_%_lido'
                     `,
                 format: 'JSONEachRow',
             }),

--- a/packages/server/controllers/entities.ts
+++ b/packages/server/controllers/entities.ts
@@ -101,6 +101,8 @@ export const getEntities = async (req: Request, res: Response) => {
                             t_validator_last_status vls
                         LEFT OUTER JOIN
                             t_eth2_pubkeys pk ON (vls.f_val_idx = pk.f_val_idx)
+                        WHERE
+                            NOT (pk.f_pool_name LIKE 'csm_%_lido')
                         GROUP BY pk.f_pool_name
                     `,
                 format: 'JSONEachRow',


### PR DESCRIPTION
Feature:
- Group up CSM Node Operators in a 'CSM Lido' entity, showing the number of active validators.
- 'CSM Lido' entity links to the CSM Lido Dashboard

Result:
![image](https://github.com/user-attachments/assets/1f21dab7-9a70-456c-9fbc-f2229ed0e208)
