### PR TITLE
[fix] optimize CSM Lido

### DIFF
--- a/packages/client/pages/lido-csm.tsx
+++ b/packages/client/pages/lido-csm.tsx
@@ -55,39 +55,8 @@ const LidoCSM = () => {
     const { themeMode } = useContext(ThemeModeContext) ?? {};
 
     useEffect(() => {
-        const fetchRewards = async () => {
-            setLoadingRewards(true);
-
-            try {
-                const rewardsPromises = operators.map(async (operator) => {
-                    const rewardData = await getOperatorRewards(operator.f_pool_name);
-                    return {name: operator.f_pool_name, rewardData };
-                });
-
-                const resolvedRewards = await Promise.all(rewardsPromises);
-
-                const rewardsMap: { [key:string]: Operator } = {};
-                resolvedRewards.forEach(({ name, rewardData }) => {
-                    rewardsMap[name] = rewardData;
-                });
-
-                setRewards(rewardsMap);
-            } catch (error) {
-                console.log(error);
-            } finally {
-                setLoadingRewards(false);
-            }
-        };
-
-        fetchRewards();
-
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [operators]);
-
-    useEffect(() => {
         if (network) {
             setOperators([]);
-            setRewards({});
             getOperators(0, 10);
         }
 
@@ -103,6 +72,8 @@ const LidoCSM = () => {
     const totalSlashed = operatorsValidator.reduce((sum, operator) => sum + operator.slashed, 0);
 
     const rewardsBar = (operator: Operator, width: number) => {
+        if (!operator || operator?.aggregated_rewards === undefined || operator?.aggregated_max_rewards === undefined)
+            return <span>N/A</span>
         return (
             <ProgressSmoothBar
                 title=''
@@ -141,6 +112,8 @@ const LidoCSM = () => {
                     limit,
                 },
             });
+
+            console.log(response.data);
 
             setOperators(response.data.operators);
             setOperatorsBalance(response.data.operatorsBalance);
@@ -190,7 +163,7 @@ const LidoCSM = () => {
                     </p>
 
                     <div className='w-[25%] text-center flex justify-center'>
-                        {loadingRewards ? 'Loading...' : rewardsBar(rewards[operator.f_pool_name], 300) ?? 'N/A'}
+                        {rewardsBar(operator, 300) ?? 'N/A'}
                     </div>
                 </LargeTableRow> 
             ))}
@@ -236,7 +209,7 @@ const LidoCSM = () => {
                             </p>
                         </div>
                         <p className='text-[14px] font-medium'>
-                            {loadingRewards ? 'Loading...' : rewardsBar(rewards[operator.f_pool_name], 160) ?? 'N/A'}
+                            {rewardsBar(operator, 160) ?? 'N/A'}
                         </p> 
                     </div>
                 </SmallTableCard>

--- a/packages/server/controllers/csm-operators.ts
+++ b/packages/server/controllers/csm-operators.ts
@@ -9,11 +9,10 @@ interface OperatorReward {
 
 export const getCsmOperators = async (req: Request, res: Response) => {
     try {
-        const { network, page = 0, limit = 10 } = req.query;
+        const { network } = req.query;
 
         const chClient = clickhouseClients[network as string];
 
-        const skip = Number(page) * Number(limit);
 
         const [operatorsBalanceResultSet, operatorsValidatorResultSet, operatorsBlockResultSet, operatorsResultSet, countResultSet, operatorsRewardsResultSet] = await Promise.all([
             chClient.query({
@@ -79,8 +78,6 @@ export const getCsmOperators = async (req: Request, res: Response) => {
                             pk.f_pool_name LIKE 'csm_%_lido'
                         GROUP BY pk.f_pool_name
                         ORDER BY LENGTH(pk.f_pool_name), pk.f_pool_name
-                        LIMIT ${Number(limit)}
-                        OFFSET ${skip};
                     `,
                 format: 'JSONEachRow',
             }),

--- a/packages/server/controllers/csm-operators.ts
+++ b/packages/server/controllers/csm-operators.ts
@@ -1,6 +1,12 @@
 import { Request, Response } from 'express';
 import { clickhouseClients } from '../config/db';
 
+interface OperatorReward {
+    f_pool_name: string;
+    aggregated_rewards: number;
+    aggregated_max_rewards: number;
+}
+
 export const getCsmOperators = async (req: Request, res: Response) => {
     try {
         const { network, page = 0, limit = 10 } = req.query;
@@ -9,7 +15,7 @@ export const getCsmOperators = async (req: Request, res: Response) => {
 
         const skip = Number(page) * Number(limit);
 
-        const [operatorsBalanceResultSet, operatorsValidatorResultSet, operatorsBlockResultSet, operatorsResultSet, countResultSet] = await Promise.all([
+        const [operatorsBalanceResultSet, operatorsValidatorResultSet, operatorsBlockResultSet, operatorsResultSet, countResultSet, operatorsRewardsResultSet] = await Promise.all([
             chClient.query({
                 query: `
                         SELECT
@@ -86,19 +92,48 @@ export const getCsmOperators = async (req: Request, res: Response) => {
                     `,
                 format: 'JSONEachRow',
             }),
+            chClient.query({
+                query: `
+                    SELECT
+                        f_pool_name,
+                        SUM(toInt64(aggregated_rewards)) AS aggregated_rewards,
+                        SUM(aggregated_max_rewards) AS aggregated_max_rewards
+                    FROM (
+                        SELECT *
+                        FROM t_pool_summary
+                        WHERE f_pool_name LIKE 'csm_operator%_lido'
+                        AND f_epoch >= (SELECT MAX(f_epoch) - 6750 FROM t_pool_summary)
+                    ) AS subquery
+                    GROUP BY f_pool_name
+                `,
+                format: 'JSONEachRow',
+            }),
         ]);
 
         const operatorsBalanceResult = await operatorsBalanceResultSet.json();
         const operatorsValidatorResult = await operatorsValidatorResultSet.json();
         const operatorsBlockResult = await operatorsBlockResultSet.json();
-        const operatorsResult = await operatorsResultSet.json();
+        const operatorsResult: [] = await operatorsResultSet.json();
         const countResult = await countResultSet.json();
+        const operatorsRewardsResult: OperatorReward[] = await operatorsRewardsResultSet.json();
+
+        const operatorsRewards = operatorsResult.map((operator: any) => {
+            const rewards: OperatorReward = operatorsRewardsResult.find(
+                (reward: any) => reward.f_pool_name === operator.f_pool_name
+            );
+
+            return {
+                ...operator,
+                aggregated_rewards: rewards?.aggregated_rewards || 0,
+                aggregated_max_rewards: rewards?.aggregated_max_rewards || 0,
+            };
+        });
 
         res.json({
             operatorsBalance: operatorsBalanceResult,
             operatorsValidator: operatorsValidatorResult,
             operatorsBlock: operatorsBlockResult,
-            operators: operatorsResult,
+            operators: operatorsRewards,
             totalCount: Number(countResult[0].count),
         });
 


### PR DESCRIPTION
Fix:
- Optimized CSM Lido loading page by adding a new query to calculate the rewards for all CSM operators

Feature:
- Fetched data for all operators during loading to prevent delay when changing pages or modifying limits.