### PR TITLE
[feat] add correctness comparison to entities and validators

### DIFF
--- a/packages/client/components/ui/TitleWithArrows.tsx
+++ b/packages/client/components/ui/TitleWithArrows.tsx
@@ -51,7 +51,7 @@ const TitleWithArrows = ({ type, value }: Props) => {
             {getArrow('left')}
 
             <Title className='capitalize' removeMarginTop>
-                {type} {!Number.isNaN(value) && value.toLocaleString()}
+                {type} {!Number.isNaN(value) && value.toLocaleString("en-US")}
             </Title>
 
             {getArrow('right')}

--- a/packages/client/pages/entity/[name].tsx
+++ b/packages/client/pages/entity/[name].tsx
@@ -151,6 +151,7 @@ const EntityComponent = ({ name, network }: Props) => {
             setEntityMonth(responseMonth.data.entity);
             setMetricsOverallNetworkMonth(responseMonth.data.metricsOverallNetwork);
             setMetricsCsmOperatorsMonth(responseMonth.data.metricsCsmOperators);
+            console.log(metricsOverallNetworkDay);
 
             if (responseHour.data.entity.aggregate_balance !== null) {
                 setShowInfoBox(false);
@@ -227,83 +228,24 @@ const EntityComponent = ({ name, network }: Props) => {
                     </div>
                 </div>
 
-                {/* Attestation flags */}
-                {entity && !checkCsm && (
-                    <div className='flex flex-col lg:flex-row gap-y-2 md:gap-y-0 md:mb-0'>
-                        <p className='md:w-52 lg:w-50 my-auto text-[var(--black)] dark:text-[var(--white)]'>Attestation flags:</p>
-
-                        <div className='flex flex-col xl:flex-row items-center gap-x-4 gap-y-2 font-medium text-[14px] text-[var(--black)] dark:text-[var(--white)]'>
-                            <ProgressSmoothBar
-                                title='Source'
-                                color='var(--black)'
-                                backgroundColor='var(--white)'
-                                percent={1 - entity.count_missing_source / entity.count_expected_attestations}
-                                width={300}
-                                tooltipColor='blue'
-                                tooltipContent={
-                                    <>
-                                        <span>Missing Source: {entity.count_missing_source?.toLocaleString()}</span>
-                                        <span>
-                                            Attestations: {entity.count_expected_attestations?.toLocaleString()}
-                                        </span>
-                                    </>
-                                }
-                                widthTooltip={220}
-                            />
-                            <ProgressSmoothBar
-                                title='Target'
-                                color='var(--black)'
-                                backgroundColor='var(--white)'
-                                percent={1 - entity.count_missing_target / entity.count_expected_attestations || 0}
-                                width={300}
-                                tooltipColor='orange'
-                                tooltipContent={
-                                    <>
-                                        <span>Missing Target: {entity.count_missing_target?.toLocaleString()}</span>
-                                        <span>
-                                            Attestations: {entity.count_expected_attestations?.toLocaleString()}
-                                        </span>
-                                    </>
-                                }
-                                widthTooltip={220}
-                            />
-
-                            <ProgressSmoothBar
-                                title='Head'
-                                color='var(--black)'
-                                backgroundColor='var(--white)'
-                                percent={1 - entity.count_missing_head / entity.count_expected_attestations}
-                                width={300}
-                                tooltipColor='purple'
-                                tooltipContent={
-                                    <>
-                                        <span>Missing Head: {entity.count_missing_head?.toLocaleString()}</span>
-                                        <span>
-                                            Attestations: {entity.count_expected_attestations?.toLocaleString()}
-                                        </span>
-                                    </>
-                                }
-                                widthTooltip={220}
-                            />
-                        </div>
+                <div className='lg:flex-row gap-y-2 md:gap-y-0 md:mb-0 mt-10'>
+                    <p className='text-[18px] md:w-[240px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>
+                        Correctness Comparison:
+                    </p>
+                    <div className="ml:h-[400px] 3xs:h-[200px] xs:h-[300px] md:w-[600px] ml:w-[750px] lg:w-[850px] xl:w-[1100px] 3xs:w-[355px] 2xs:w-[415px] xs:w-[520px] xl:mx-auto 3xs:ml-[-54px] md:ml-[-40px]" >
+                        <BarChartComponent
+                            data={checkCsm ? [
+                                {name: 'Source', [cleanedName]: (1 - entity.count_missing_source / entity.count_expected_attestations), 'CSM': csmOperators?.missing_source, 'Overall Network': overallNetwork?.missing_source},
+                                {name: 'Target', [cleanedName]: (1 - entity.count_missing_target / entity.count_expected_attestations), 'CSM': csmOperators?.missing_target, 'Overall Network': overallNetwork?.missing_target},
+                                {name: 'Head', [cleanedName]: (1 - entity.count_missing_head / entity.count_expected_attestations), 'CSM': csmOperators?.missing_head, 'Overall Network': overallNetwork?.missing_head},
+                            ] : [
+                                {name: 'Source', [cleanedName]: (1 - entity.count_missing_source / entity.count_expected_attestations), 'Overall Network': overallNetwork?.missing_source},
+                                {name: 'Target', [cleanedName]: (1 - entity.count_missing_target / entity.count_expected_attestations), 'Overall Network': overallNetwork?.missing_target},
+                                {name: 'Head', [cleanedName]: (1 - entity.count_missing_head / entity.count_expected_attestations), 'Overall Network': overallNetwork?.missing_head},
+                            ]}
+                        ></BarChartComponent>
                     </div>
-                )}
-                {checkCsm && csmOperators &&(
-                    <div className='lg:flex-row gap-y-2 md:gap-y-0 md:mb-0 mt-10'>
-                        <p className='text-[18px] md:w-[240px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>
-                            Correctness Comparison:
-                        </p>
-                        <div className="ml:h-[400px] 3xs:h-[200px] xs:h-[300px] md:w-[600px] ml:w-[750px] lg:w-[850px] xl:w-[1100px] 3xs:w-[355px] 2xs:w-[415px] xs:w-[520px] xl:mx-auto 3xs:ml-[-54px] md:ml-[-40px]" >
-                            <BarChartComponent
-                                data={[
-                                    {name: 'Source', [cleanedName]: (1 - entity.count_missing_source / entity.count_expected_attestations), 'CSM': csmOperators?.missing_source, 'Overall Network': overallNetwork?.missing_source},
-                                    {name: 'Target', [cleanedName]: (1 - entity.count_missing_target / entity.count_expected_attestations), 'CSM': csmOperators?.missing_target, 'Overall Network': overallNetwork?.missing_target},
-                                    {name: 'Head', [cleanedName]: (1 - entity.count_missing_head / entity.count_expected_attestations), 'CSM': csmOperators?.missing_head, 'Overall Network': overallNetwork?.missing_head},
-                                ]}
-                            ></BarChartComponent>
-                        </div>
-                    </div>
-                )}
+                </div>
             </>
         );
     };
@@ -436,7 +378,9 @@ const EntityComponent = ({ name, network }: Props) => {
                         }}
                     >
                         <div className='flex flex-col md:gap-y-4 3xs:gap-y-4 text-[14px] font-medium md:text-[16px] text-[var(--darkGray)] dark:text-[var(--white)]'>
-                            <p className='text-[18px] uppercase font-medium md:py-4 3xs:py-2 text-center text-[var(--black)] dark:text-[var(--white)]'>Entity performance:</p>
+                            <p className='text-[18px] uppercase font-medium md:py-4 3xs:py-2 text-center text-[var(--black)] dark:text-[var(--white)]'>
+                                Entity performance:
+                            </p>
                             {tabPageIndexEntityPerformance === 0 && getEntityPerformance(entityHour as Entity, metricsOverallNetworkHour as Metrics, metricsCsmOperatorshour as Metrics)}
                             {tabPageIndexEntityPerformance === 1 && getEntityPerformance(entityDay as Entity, metricsOverallNetworkDay as Metrics, metricsCsmOperatorsDay as Metrics)}
                             {tabPageIndexEntityPerformance === 2 && getEntityPerformance(entityWeek as Entity, metricsOverallNetworkWeek as Metrics, metricsCsmOperatorsWeek as Metrics)}

--- a/packages/client/pages/validator/[id].tsx
+++ b/packages/client/pages/validator/[id].tsx
@@ -113,30 +113,13 @@ const ValidatorComponent = ({ id, network }: Props) => {
             const week = 1575;
             const month = 6750;
 
-            const [responseHour, genesisBlock] = await Promise.all([
+            const [responseHour, responseDay, responseWeek, responseMonth, genesisBlock] = await Promise.all([
                 axiosClient.get(`/api/validators/${id}`, {
                     params: {
                         network,
                         numberEpochs: hour,
                     },
                 }),
-                axiosClient.get(`/api/networks/block/genesis`, {
-                    params: {
-                        network,
-                    },
-                }),
-            ]);
-
-            setBlockGenesis(genesisBlock.data.block_genesis);
-            setValidatorHour(responseHour.data.validator);
-            setMetricsOverallNetworkHour(responseHour.data.metricsOverallNetwork);
-            
-            if (responseHour.data.validator) {
-                setShowInfoBox(false);
-            } else {
-                setShowInfoBox(true);
-            }
-            const [responseDay, responseWeek, responseMonth] = await Promise.all([
                 axiosClient.get(`/api/validators/${id}`, {
                     params: {
                         network,
@@ -155,13 +138,29 @@ const ValidatorComponent = ({ id, network }: Props) => {
                         numberEpochs: month,
                     },
                 }),
+                axiosClient.get(`/api/networks/block/genesis`, {
+                    params: {
+                        network,
+                    },
+                }),
             ]);
+
+            setBlockGenesis(genesisBlock.data.block_genesis);
+            setValidatorHour(responseHour.data.validator);
             setValidatorDay(responseDay.data.validator);
             setValidatorWeek(responseWeek.data.validator);
             setValidatorMonth(responseMonth.data.validator);
+            setMetricsOverallNetworkHour(responseHour.data.metricsOverallNetwork);
             setMetricsOverallNetworkDay(responseDay.data.metricsOverallNetwork);
             setMetricsOverallNetworkWeek(responseWeek.data.metricsOverallNetwork);
             setMetricsOverallNetworkMonth(responseMonth.data.metricsOverallNetwork);
+
+            if (responseHour.data.validator) {
+                setShowInfoBox(false);
+            } else {
+                setShowInfoBox(true);
+            }
+
         } catch (error) {
             console.log(error);
             setShowInfoBox(true);

--- a/packages/client/pages/validator/[id].tsx
+++ b/packages/client/pages/validator/[id].tsx
@@ -27,6 +27,8 @@ import CardContent from '../../components/ui/CardContent';
 import { LargeTable, LargeTableHeader, LargeTableRow, SmallTable, SmallTableCard } from '../../components/ui/Table';
 import ShareMenu from '../../components/ui/ShareMenu';
 
+import BarChartComponent from '../../components/ui/BarChart';
+
 // Types
 import { Validator, Slot, Withdrawal } from '../../types';
 
@@ -35,6 +37,16 @@ interface Props {
     id: number;
     network: string;
 }
+
+type Metrics = {
+    missing_source: number;
+    missing_target: number;
+    missing_head: number;
+    count_active_vals: number;
+    count_missing_source: number;
+    count_missing_target: number;
+    count_missing_head: number;
+};
 
 // Server Side Props
 export const getServerSideProps: GetServerSideProps = async context => {
@@ -74,6 +86,10 @@ const ValidatorComponent = ({ id, network }: Props) => {
     const [loadingProposedBlocks, setLoadingProposedBlocks] = useState(true);
     const [loadingWithdrawals, setLoadingWithdrawals] = useState(true);
     const [blockGenesis, setBlockGenesis] = useState(0);
+    const [metricsOverallNetworkHour, setMetricsOverallNetworkHour] = useState<Metrics | null>(null);
+    const [metricsOverallNetworkDay, setMetricsOverallNetworkDay] = useState<Metrics | null>(null);
+    const [metricsOverallNetworkWeek, setMetricsOverallNetworkWeek] = useState<Metrics | null>(null);
+    const [metricsOverallNetworkMonth, setMetricsOverallNetworkMonth] = useState<Metrics | null>(null);
 
     // UseEffect
     useEffect(() => {
@@ -133,6 +149,10 @@ const ValidatorComponent = ({ id, network }: Props) => {
             setValidatorDay(responseDay.data.validator);
             setValidatorWeek(responseWeek.data.validator);
             setValidatorMonth(responseMonth.data.validator);
+            setMetricsOverallNetworkHour(responseHour.data.metrics);
+            setMetricsOverallNetworkDay(responseDay.data.metrics);
+            setMetricsOverallNetworkWeek(responseWeek.data.metrics);
+            setMetricsOverallNetworkMonth(responseMonth.data.metrics);
 
             if (responseHour.data.validator) {
                 setShowInfoBox(false);
@@ -272,10 +292,10 @@ const ValidatorComponent = ({ id, network }: Props) => {
             >
                 <div className='flex flex-col gap-y-6 text-[14px] font-medium md:text-[16px] text-[var(--black)] dark:text-[var(--white)]'>
                         <p className='text-[18px] uppercase font-medium md:py-4 3xs:py-2 text-center'>Validator performance:</p>
-                        {tabPageIndexValidatorPerformance === 0 && getValidatorPerformance(validatorHour as Validator)}
-                        {tabPageIndexValidatorPerformance === 1 && getValidatorPerformance(validatorDay as Validator)}
-                        {tabPageIndexValidatorPerformance === 2 && getValidatorPerformance(validatorWeek as Validator)}
-                        {tabPageIndexValidatorPerformance === 3 && getValidatorPerformance(validatorMonth as Validator)}
+                        {tabPageIndexValidatorPerformance === 0 && getValidatorPerformance(validatorHour as Validator, metricsOverallNetworkHour as Metrics)}
+                        {tabPageIndexValidatorPerformance === 1 && getValidatorPerformance(validatorDay as Validator, metricsOverallNetworkDay as Metrics)}
+                        {tabPageIndexValidatorPerformance === 2 && getValidatorPerformance(validatorWeek as Validator, metricsOverallNetworkWeek as Metrics)}
+                        {tabPageIndexValidatorPerformance === 3 && getValidatorPerformance(validatorMonth as Validator, metricsOverallNetworkMonth as Metrics)}
                 </div>
             </div>
         </>
@@ -316,7 +336,7 @@ const ValidatorComponent = ({ id, network }: Props) => {
 
     //VALIDATOR PERFORMANCE TABLE
     //View validator performance table
-    const getValidatorPerformance = (validator: Validator) => (
+    const getValidatorPerformance = (validator: Validator, overallNetwork: Metrics) => (
         <>
             <div className='flex flex-col md:flex-row gap-y-2 md:gap-y-0 md:mb-0'>
                 <p className='md:w-52 lg:w-50 my-auto'>Rewards:</p>
@@ -350,60 +370,6 @@ const ValidatorComponent = ({ id, network }: Props) => {
 
             {/* Attestation flags */}
             <div className='flex flex-col lg:flex-row gap-y-2 md:gap-y-0 md:mb-0'>
-                <p className='md:w-52 lg:w-50 my-auto'>Attestation flags:</p>
-
-                {validator && (
-                    <div className='flex flex-col xl:flex-row items-center gap-x-4 gap-y-2 font-medium text-[14px]'>
-                        <ProgressSmoothBar
-                            title='Source'
-                            color='var(--black)'
-                            backgroundColor='var(--white)'
-                            percent={1 - validator.count_missing_source / validator.count_attestations}
-                            width={300}
-                            tooltipColor='blue'
-                            tooltipContent={
-                                <>
-                                    <span>Missing Source: {validator.count_missing_source?.toLocaleString()}</span>
-                                    <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
-                                </>
-                            }
-                            widthTooltip={220}
-                        />
-
-                        <ProgressSmoothBar
-                            title='Target'
-                            color='var(--black)'
-                            backgroundColor='var(--white)'
-                            percent={1 - validator.count_missing_target / validator.count_attestations}
-                            width={300}
-                            tooltipColor='orange'
-                            tooltipContent={
-                                <>
-                                    <span>Missing Target: {validator.count_missing_target?.toLocaleString()}</span>
-                                    <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
-                                </>
-                            }
-                            widthTooltip={220}
-                        />
-
-                        <ProgressSmoothBar
-                            title='Head'
-                            color='var(--black)'
-                            backgroundColor='var(--white)'
-                            percent={1 - validator.count_missing_head / validator.count_attestations}
-                            width={300}
-                            tooltipColor='purple'
-                            tooltipContent={
-                                <>
-                                    <span>Missing Head: {validator.count_missing_head?.toLocaleString()}</span>
-                                    <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
-                                </>
-                            }
-                            widthTooltip={220}
-                        />
-                    </div>
-                )}
-            </div>
 
             <div className='3xs:flex flex-col 3xs:flex-row items-center justify-between md:justify-start gap-x-1'>
                 <p className='md:w-52 lg:w-50 md:md-0'>Blocks:</p>
@@ -422,6 +388,74 @@ const ValidatorComponent = ({ id, network }: Props) => {
                         bg='var(--missedRed)'
                         boxShadow='var(--boxShadowRed)'
                     />
+                </div>
+            </div>
+            <p className='md:w-52 lg:w-50 my-auto'>Attestation flags:</p>
+
+            {validator && (
+                <div className='flex flex-col xl:flex-row items-center gap-x-4 gap-y-2 font-medium text-[14px]'>
+                    <ProgressSmoothBar
+                        title='Source'
+                        color='var(--black)'
+                        backgroundColor='var(--white)'
+                        percent={1 - validator.count_missing_source / validator.count_attestations}
+                        width={300}
+                        tooltipColor='blue'
+                        tooltipContent={
+                            <>
+                                <span>Missing Source: {validator.count_missing_source?.toLocaleString()}</span>
+                                <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
+                            </>
+                        }
+                        widthTooltip={220}
+                    />
+
+                    <ProgressSmoothBar
+                        title='Target'
+                        color='var(--black)'
+                        backgroundColor='var(--white)'
+                        percent={1 - validator.count_missing_target / validator.count_attestations}
+                        width={300}
+                        tooltipColor='orange'
+                        tooltipContent={
+                            <>
+                                <span>Missing Target: {validator.count_missing_target?.toLocaleString()}</span>
+                                <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
+                            </>
+                        }
+                        widthTooltip={220}
+                    />
+
+                    <ProgressSmoothBar
+                        title='Head'
+                        color='var(--black)'
+                        backgroundColor='var(--white)'
+                        percent={1 - validator.count_missing_head / validator.count_attestations}
+                        width={300}
+                        tooltipColor='purple'
+                        tooltipContent={
+                            <>
+                                <span>Missing Head: {validator.count_missing_head?.toLocaleString()}</span>
+                                <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
+                            </>
+                        }
+                        widthTooltip={220}
+                    />
+                </div>
+            )}
+            </div>
+            <div className='lg:flex-row gap-y-2 md:gap-y-0 md:mb-0 mt-10'>
+                <p className='text-[18px] md:w-[240px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>
+                    Correctness Comparison:
+                </p>
+                <div className="ml:h-[400px] 3xs:h-[200px] xs:h-[300px] md:w-[600px] ml:w-[750px] lg:w-[850px] xl:w-[1100px] 3xs:w-[355px] 2xs:w-[415px] xs:w-[520px] xl:mx-auto 3xs:ml-[-54px] md:ml-[-40px]" >
+                    <BarChartComponent
+                        data={[
+                            {name: 'Source', [id]: (1 - validator.count_missing_source / validator.count_attestations), 'Overall Network': overallNetwork?.missing_source},
+                            {name: 'Target', [id]: (1 - validator.count_missing_target / validator.count_attestations), 'Overall Network': overallNetwork?.missing_target},
+                            {name: 'Head', [id]: (1 - validator.count_missing_head / validator.count_attestations), 'Overall Network': overallNetwork?.missing_head},
+                        ]}
+                    ></BarChartComponent>
                 </div>
             </div>
         </>

--- a/packages/client/pages/validator/[id].tsx
+++ b/packages/client/pages/validator/[id].tsx
@@ -113,13 +113,30 @@ const ValidatorComponent = ({ id, network }: Props) => {
             const week = 1575;
             const month = 6750;
 
-            const [responseHour, responseDay, responseWeek, responseMonth, genesisBlock] = await Promise.all([
+            const [responseHour, genesisBlock] = await Promise.all([
                 axiosClient.get(`/api/validators/${id}`, {
                     params: {
                         network,
                         numberEpochs: hour,
                     },
                 }),
+                axiosClient.get(`/api/networks/block/genesis`, {
+                    params: {
+                        network,
+                    },
+                }),
+            ]);
+
+            setBlockGenesis(genesisBlock.data.block_genesis);
+            setValidatorHour(responseHour.data.validator);
+            setMetricsOverallNetworkHour(responseHour.data.metricsOverallNetwork);
+            
+            if (responseHour.data.validator) {
+                setShowInfoBox(false);
+            } else {
+                setShowInfoBox(true);
+            }
+            const [responseDay, responseWeek, responseMonth] = await Promise.all([
                 axiosClient.get(`/api/validators/${id}`, {
                     params: {
                         network,
@@ -138,31 +155,13 @@ const ValidatorComponent = ({ id, network }: Props) => {
                         numberEpochs: month,
                     },
                 }),
-                axiosClient.get(`/api/networks/block/genesis`, {
-                    params: {
-                        network,
-                    },
-                }),
             ]);
-
-            setBlockGenesis(genesisBlock.data.block_genesis);
-            setValidatorHour(responseHour.data.validator);
             setValidatorDay(responseDay.data.validator);
             setValidatorWeek(responseWeek.data.validator);
             setValidatorMonth(responseMonth.data.validator);
-            setMetricsOverallNetworkHour(responseHour.data.metricsOverallNetwork);
             setMetricsOverallNetworkDay(responseDay.data.metricsOverallNetwork);
             setMetricsOverallNetworkWeek(responseWeek.data.metricsOverallNetwork);
             setMetricsOverallNetworkMonth(responseMonth.data.metricsOverallNetwork);
-
-            console.log(responseHour.data.validator);
-            
-
-            if (responseHour.data.validator) {
-                setShowInfoBox(false);
-            } else {
-                setShowInfoBox(true);
-            }
         } catch (error) {
             console.log(error);
             setShowInfoBox(true);

--- a/packages/client/pages/validator/[id].tsx
+++ b/packages/client/pages/validator/[id].tsx
@@ -155,7 +155,7 @@ const ValidatorComponent = ({ id, network }: Props) => {
             setMetricsOverallNetworkWeek(responseWeek.data.metricsOverallNetwork);
             setMetricsOverallNetworkMonth(responseMonth.data.metricsOverallNetwork);
 
-            console.log();
+            console.log(responseHour.data.validator);
             
 
             if (responseHour.data.validator) {
@@ -392,62 +392,6 @@ const ValidatorComponent = ({ id, network }: Props) => {
                 </div>
             </div>
 
-            {/* Attestation flags */}
-            <div className='flex flex-col lg:flex-row gap-y-2 md:gap-y-0 md:mb-0'>
-                <p className='md:w-52 lg:w-50 my-auto'>Attestation flags:</p>
-
-                {validator && (
-                    <div className='flex flex-col xl:flex-row items-center gap-x-4 gap-y-2 font-medium text-[14px]'>
-                        <ProgressSmoothBar
-                            title='Source'
-                            color='var(--black)'
-                            backgroundColor='var(--white)'
-                            percent={1 - validator.count_missing_source / validator.count_attestations}
-                            width={300}
-                            tooltipColor='blue'
-                            tooltipContent={
-                                <>
-                                    <span>Missing Source: {validator.count_missing_source?.toLocaleString()}</span>
-                                    <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
-                                </>
-                            }
-                            widthTooltip={220}
-                        />
-
-                        <ProgressSmoothBar
-                            title='Target'
-                            color='var(--black)'
-                            backgroundColor='var(--white)'
-                            percent={1 - validator.count_missing_target / validator.count_attestations}
-                            width={300}
-                            tooltipColor='orange'
-                            tooltipContent={
-                                <>
-                                    <span>Missing Target: {validator.count_missing_target?.toLocaleString()}</span>
-                                    <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
-                                </>
-                            }
-                            widthTooltip={220}
-                        />
-
-                        <ProgressSmoothBar
-                            title='Head'
-                            color='var(--black)'
-                            backgroundColor='var(--white)'
-                            percent={1 - validator.count_missing_head / validator.count_attestations}
-                            width={300}
-                            tooltipColor='purple'
-                            tooltipContent={
-                                <>
-                                    <span>Missing Head: {validator.count_missing_head?.toLocaleString()}</span>
-                                    <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
-                                </>
-                            }
-                            widthTooltip={220}
-                        />
-                    </div>
-                )}
-            </div>
             <div className='lg:flex-row gap-y-2 md:gap-y-0 md:mb-0 mt-10'>
                 <p className='text-[18px] md:w-[240px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>
                     Correctness Comparison:

--- a/packages/client/pages/validator/[id].tsx
+++ b/packages/client/pages/validator/[id].tsx
@@ -31,6 +31,7 @@ import BarChartComponent from '../../components/ui/BarChart';
 
 // Types
 import { Validator, Slot, Withdrawal } from '../../types';
+import { log } from 'console';
 
 // Props
 interface Props {
@@ -149,10 +150,13 @@ const ValidatorComponent = ({ id, network }: Props) => {
             setValidatorDay(responseDay.data.validator);
             setValidatorWeek(responseWeek.data.validator);
             setValidatorMonth(responseMonth.data.validator);
-            setMetricsOverallNetworkHour(responseHour.data.metrics);
-            setMetricsOverallNetworkDay(responseDay.data.metrics);
-            setMetricsOverallNetworkWeek(responseWeek.data.metrics);
-            setMetricsOverallNetworkMonth(responseMonth.data.metrics);
+            setMetricsOverallNetworkHour(responseHour.data.metricsOverallNetwork);
+            setMetricsOverallNetworkDay(responseDay.data.metricsOverallNetwork);
+            setMetricsOverallNetworkWeek(responseWeek.data.metricsOverallNetwork);
+            setMetricsOverallNetworkMonth(responseMonth.data.metricsOverallNetwork);
+
+            console.log();
+            
 
             if (responseHour.data.validator) {
                 setShowInfoBox(false);
@@ -368,9 +372,6 @@ const ValidatorComponent = ({ id, network }: Props) => {
                 </p>
             </div>
 
-            {/* Attestation flags */}
-            <div className='flex flex-col lg:flex-row gap-y-2 md:gap-y-0 md:mb-0'>
-
             <div className='3xs:flex flex-col 3xs:flex-row items-center justify-between md:justify-start gap-x-1'>
                 <p className='md:w-52 lg:w-50 md:md-0'>Blocks:</p>
 
@@ -390,59 +391,62 @@ const ValidatorComponent = ({ id, network }: Props) => {
                     />
                 </div>
             </div>
-            <p className='md:w-52 lg:w-50 my-auto'>Attestation flags:</p>
 
-            {validator && (
-                <div className='flex flex-col xl:flex-row items-center gap-x-4 gap-y-2 font-medium text-[14px]'>
-                    <ProgressSmoothBar
-                        title='Source'
-                        color='var(--black)'
-                        backgroundColor='var(--white)'
-                        percent={1 - validator.count_missing_source / validator.count_attestations}
-                        width={300}
-                        tooltipColor='blue'
-                        tooltipContent={
-                            <>
-                                <span>Missing Source: {validator.count_missing_source?.toLocaleString()}</span>
-                                <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
-                            </>
-                        }
-                        widthTooltip={220}
-                    />
+            {/* Attestation flags */}
+            <div className='flex flex-col lg:flex-row gap-y-2 md:gap-y-0 md:mb-0'>
+                <p className='md:w-52 lg:w-50 my-auto'>Attestation flags:</p>
 
-                    <ProgressSmoothBar
-                        title='Target'
-                        color='var(--black)'
-                        backgroundColor='var(--white)'
-                        percent={1 - validator.count_missing_target / validator.count_attestations}
-                        width={300}
-                        tooltipColor='orange'
-                        tooltipContent={
-                            <>
-                                <span>Missing Target: {validator.count_missing_target?.toLocaleString()}</span>
-                                <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
-                            </>
-                        }
-                        widthTooltip={220}
-                    />
+                {validator && (
+                    <div className='flex flex-col xl:flex-row items-center gap-x-4 gap-y-2 font-medium text-[14px]'>
+                        <ProgressSmoothBar
+                            title='Source'
+                            color='var(--black)'
+                            backgroundColor='var(--white)'
+                            percent={1 - validator.count_missing_source / validator.count_attestations}
+                            width={300}
+                            tooltipColor='blue'
+                            tooltipContent={
+                                <>
+                                    <span>Missing Source: {validator.count_missing_source?.toLocaleString()}</span>
+                                    <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
+                                </>
+                            }
+                            widthTooltip={220}
+                        />
 
-                    <ProgressSmoothBar
-                        title='Head'
-                        color='var(--black)'
-                        backgroundColor='var(--white)'
-                        percent={1 - validator.count_missing_head / validator.count_attestations}
-                        width={300}
-                        tooltipColor='purple'
-                        tooltipContent={
-                            <>
-                                <span>Missing Head: {validator.count_missing_head?.toLocaleString()}</span>
-                                <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
-                            </>
-                        }
-                        widthTooltip={220}
-                    />
-                </div>
-            )}
+                        <ProgressSmoothBar
+                            title='Target'
+                            color='var(--black)'
+                            backgroundColor='var(--white)'
+                            percent={1 - validator.count_missing_target / validator.count_attestations}
+                            width={300}
+                            tooltipColor='orange'
+                            tooltipContent={
+                                <>
+                                    <span>Missing Target: {validator.count_missing_target?.toLocaleString()}</span>
+                                    <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
+                                </>
+                            }
+                            widthTooltip={220}
+                        />
+
+                        <ProgressSmoothBar
+                            title='Head'
+                            color='var(--black)'
+                            backgroundColor='var(--white)'
+                            percent={1 - validator.count_missing_head / validator.count_attestations}
+                            width={300}
+                            tooltipColor='purple'
+                            tooltipContent={
+                                <>
+                                    <span>Missing Head: {validator.count_missing_head?.toLocaleString()}</span>
+                                    <span>Attestations: {validator.count_attestations?.toLocaleString()}</span>
+                                </>
+                            }
+                            widthTooltip={220}
+                        />
+                    </div>
+                )}
             </div>
             <div className='lg:flex-row gap-y-2 md:gap-y-0 md:mb-0 mt-10'>
                 <p className='text-[18px] md:w-[240px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>

--- a/packages/client/pages/validator/[id].tsx
+++ b/packages/client/pages/validator/[id].tsx
@@ -392,16 +392,16 @@ const ValidatorComponent = ({ id, network }: Props) => {
                 </div>
             </div>
 
-            <div className='lg:flex-row gap-y-2 md:gap-y-0 md:mb-0 mt-10'>
+            <div className='lg:flex-row md:gap-y-0 md:mb-0 mt-10'>
                 <p className='text-[18px] md:w-[240px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>
                     Correctness Comparison:
                 </p>
                 <div className="ml:h-[400px] 3xs:h-[200px] xs:h-[300px] md:w-[600px] ml:w-[750px] lg:w-[850px] xl:w-[1100px] 3xs:w-[355px] 2xs:w-[415px] xs:w-[520px] xl:mx-auto 3xs:ml-[-54px] md:ml-[-40px]" >
                     <BarChartComponent
                         data={[
-                            {name: 'Source', [id]: (1 - validator.count_missing_source / validator.count_attestations), 'Overall Network': overallNetwork?.missing_source},
-                            {name: 'Target', [id]: (1 - validator.count_missing_target / validator.count_attestations), 'Overall Network': overallNetwork?.missing_target},
-                            {name: 'Head', [id]: (1 - validator.count_missing_head / validator.count_attestations), 'Overall Network': overallNetwork?.missing_head},
+                            {name: 'Source', ['Validator ' + id]: (1 - validator.count_missing_source / validator.count_attestations), 'Overall Network': overallNetwork?.missing_source},
+                            {name: 'Target', ['Validator ' + id]: (1 - validator.count_missing_target / validator.count_attestations), 'Overall Network': overallNetwork?.missing_target},
+                            {name: 'Head', ['Validator ' + id]: (1 - validator.count_missing_head / validator.count_attestations), 'Overall Network': overallNetwork?.missing_head},
                         ]}
                     ></BarChartComponent>
                 </div>

--- a/packages/client/pages/validator/[id].tsx
+++ b/packages/client/pages/validator/[id].tsx
@@ -31,7 +31,6 @@ import BarChartComponent from '../../components/ui/BarChart';
 
 // Types
 import { Validator, Slot, Withdrawal } from '../../types';
-import { log } from 'console';
 
 // Props
 interface Props {

--- a/packages/server/controllers/entities.ts
+++ b/packages/server/controllers/entities.ts
@@ -58,26 +58,24 @@ export const getEntity = async (req: Request, res: Response) => {
                     `,
                 format: 'JSONEachRow',
             }),
+            chClient.query({
+                query: `
+                        SELECT
+                            1 - SUM(f_missing_source) / SUM(f_num_att_vals) AS missing_source,
+                            1 - SUM(f_missing_target) / SUM(f_num_att_vals) AS missing_target,
+                            1 - SUM(f_missing_head) / SUM(f_num_att_vals) AS missing_head
+                        FROM (
+                            SELECT *
+                            FROM t_epoch_metrics_summary
+                            ORDER BY f_epoch DESC
+                            LIMIT ${Number(numberEpochs)}
+                        );
+                    `,
+                format: 'JSONEachRow',
+            }),
         ];
         
         if (name.includes('csm_')) {
-            queries.push(
-                chClient.query({
-                    query: `
-                            SELECT
-                                1 - SUM(f_missing_source) / SUM(f_num_att_vals) AS missing_source,
-                                1 - SUM(f_missing_target) / SUM(f_num_att_vals) AS missing_target,
-                                1 - SUM(f_missing_head) / SUM(f_num_att_vals) AS missing_head
-                            FROM (
-                                SELECT *
-                                FROM t_epoch_metrics_summary
-                                ORDER BY f_epoch DESC
-                                LIMIT ${Number(numberEpochs)}
-                            );
-                        `,
-                    format: 'JSONEachRow',
-                }),
-            );
             queries.push(
                 chClient.query({
                     query: `
@@ -107,12 +105,11 @@ export const getEntity = async (req: Request, res: Response) => {
         const entityStatsResult = await results[0].json();
         const blocksProposedResult = await results[1].json();
         const entityPerformanceResult = await results[2].json();
+        const metricsOverallNetworkResult = await results[3].json();
         
-        let metricsOverallNetworkResult = [];
         let metricsCsmOperatorsResult = [];
 
         if (name.includes('csm_')) {
-            metricsOverallNetworkResult = await results[3].json();
             metricsCsmOperatorsResult = await results[4].json();
         }
 


### PR DESCRIPTION
Feature:
- Add the correctness comparison using the bar chart to compare entities/validators and overall network

Fix:
- Fix number format in the TitleWithArrows components that was causing an unexpected error

Result:
- Validator:
![image](https://github.com/user-attachments/assets/25ad5b77-c37f-4b4c-9bf2-013b2a469814)
- Entity:
![image](https://github.com/user-attachments/assets/6a35dda5-cec4-4199-b109-7bf0d5e8b827)

