### PR TITLE
[fix] responsive bar chart on mobile devices

### DIFF
--- a/packages/client/components/ui/BarChart.tsx
+++ b/packages/client/components/ui/BarChart.tsx
@@ -6,9 +6,10 @@ interface Props {
     data: Record<string, any>[];
     width?: number;
     height?: number;
+    legend?: boolean;
 }
 
-const BarChartComponent: React.FC<Props> = ({ data, width, height }) => {
+const BarChartComponent: React.FC<Props> = ({ data, width, height, legend = true }) => {
     const barKeys = data[0] ? Object.keys(data[0]).filter(key => key !== 'name') : [];
     const { themeMode } = useContext(ThemeModeContext) ?? {};
     const minValue = Math.min(...data.flatMap(item => barKeys.map(key => item[key]))); 
@@ -66,9 +67,9 @@ const BarChartComponent: React.FC<Props> = ({ data, width, height }) => {
                     cursor={themeMode?.darkMode ? { fill: 'var(--bgDarkMode)' } : { fill: 'var(--bgBar)' }}
                     contentStyle={themeMode?.darkMode ? { backgroundColor: 'var(--bgDarkMode)', color: 'var(--white)' } : { backgroundColor: 'var(--white)', color: 'var(--black)' }}
                 />
-                <Legend
-                    wrapperStyle={smallScreen ? { fontSize: '10px', margin: '0 auto', display: 'block', width: '100%' } : { fontSize: '14px' }}
-                />
+                {legend && <Legend
+                    wrapperStyle={smallScreen ? { fontSize: '10px', margin: '0 0', display: 'block', width: '100%' } : { fontSize: '14px' }}
+                />}
                 {barKeys.map((key, index) => (
                     <Bar
                         key={key}
@@ -78,12 +79,12 @@ const BarChartComponent: React.FC<Props> = ({ data, width, height }) => {
                     >
                         <LabelList
                             dataKey={key}
-                            position={smallScreen ? 'top' : 'middle'}
+                            position={'middle'}
                             offset={2}
                             style={{
-                                fill: !themeMode?.darkMode && smallScreen ? 'var(--black)' : 'var(--white)'
+                                fill: themeMode?.darkMode ? 'var(--black)' : 'var(--white)'
                                 }}
-                            className='3xs:text-[8px] 2xs:text-[9px] md:text-[13px] ml:text-[16px]'
+                            className='3xs:text-[12px] md:text-[13px] ml:text-[16px]'
                             formatter={(value: number) => `${(value * 100).toFixed(1)}%`}
                         />
                     </Bar>

--- a/packages/client/components/ui/BarChart.tsx
+++ b/packages/client/components/ui/BarChart.tsx
@@ -56,7 +56,6 @@ const BarChartComponent: React.FC<Props> = ({ data, width, height, legend = true
                         fontSize: smallScreen ? '10px' : '14px',
                     }}
                     domain={[yMin, 1]}
-                    padding={{top: smallScreen ? 12 : 0}}
                     ticks={[0.5, 0.65, 0.8, 0.9, 1]}
                     overlineThickness={0}
                 />

--- a/packages/client/pages/entity/[name].tsx
+++ b/packages/client/pages/entity/[name].tsx
@@ -285,7 +285,7 @@ const EntityComponent = ({ name, network }: Props) => {
                 <p className='text-[18px] md:w-[240px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>
                     Correctness Comparison:
                 </p>
-                <div className="3xs:h-[200px] xs:h-[300px] md:w-[600px] ml:w-[750px] lg:w-[850px] xl:w-[1100px] 3xs:w-[355px] 2xs:w-[415px] xs:w-[520px] xl:mx-auto 3xs:ml-[-54px] md:ml-[-40px]" >
+                <div className="3xs:h-[200px] xs:h-[300px] lg:w-[850px] xl:w-[1100px] 3xs:w-[355px] 2xs:w-[415px] xs:w-[520px] xl:mx-auto 3xs:ml-[-54px] md:ml-[-40px]" >
                     <BarChartComponent
                         data={checkCsm ? [
                             {name: 'Source', [cleanedName]: (1 - entity.count_missing_source / entity.count_expected_attestations), 'CSM': csmOperators?.missing_source, 'Overall Network': overallNetwork?.missing_source},
@@ -374,7 +374,7 @@ const EntityComponent = ({ name, network }: Props) => {
                     <p className='text-[18px] 3xs:w-[290px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>
                         Participation Rate Comparison:
                     </p>
-                    <div className="3xs:h-[220px] lg:h-[300px] 3xs:w-[250px] 3xs:mx-auto xl:mx-auto lg:ml-[-25px]" >
+                    <div className="3xs:h-[220px] lg:h-[300px] 3xs:w-[250px] lg:w-[400px] 3xs:mx-auto xl:mx-auto lg:ml-[-25px]" >
                         <BarChartComponent
                             data={checkCsm ? [
                                 {name: '', [cleanedName]: partRate, 'CSM': partRateCsm, 'Overall Network': partRateOverall},

--- a/packages/client/pages/entity/[name].tsx
+++ b/packages/client/pages/entity/[name].tsx
@@ -265,7 +265,7 @@ const EntityComponent = ({ name, network }: Props) => {
                         legend={false}
                     ></BarChartComponent>
                 </div>
-                <div className="3xs:h-[220px] lg:h-[300px] 3xs:w-[250px] 3xs:mx-auto" >
+                <div className="3xs:h-[230px] lg:h-[300px] 3xs:w-[250px] 3xs:mx-auto" >
                     <BarChartComponent
                         data={checkCsm ? [
                             {name: 'Head', [cleanedName]: (1 - entity.count_missing_head / entity.count_expected_attestations), 'CSM': csmOperators?.missing_head, 'Overall Network': overallNetwork?.missing_head},

--- a/packages/client/pages/entity/[name].tsx
+++ b/packages/client/pages/entity/[name].tsx
@@ -574,6 +574,8 @@ const EntityComponent = ({ name, network }: Props) => {
                 </div>
             )}
 
+            <Title className='mb-5 font-medium' removeMarginTop>{cleanedName}'s Validators</Title>
+
             {validatorsCount > 0 && (
                 <Pagination
                     currentPage={currentPage}

--- a/packages/client/pages/entity/[name].tsx
+++ b/packages/client/pages/entity/[name].tsx
@@ -239,6 +239,68 @@ const EntityComponent = ({ name, network }: Props) => {
         }
     };
 
+    const getCorrectnessComparisonMobile = (entity: Entity, overallNetwork: Metrics, csmOperators: Metrics) => {
+        return (
+            <div className='lg:flex-row gap-y-2 md:gap-y-0 md:mb-0'>
+                <p className='text-[18px] 3xs:w-[240px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>
+                    Correctness Comparison:
+                </p>
+                <div className="3xs:h-[200px] lg:h-[300px] 3xs:w-[250px] 3xs:mx-auto" >
+                    <BarChartComponent
+                        data={checkCsm ? [
+                            {name: 'Source', [cleanedName]: (1 - entity.count_missing_source / entity.count_expected_attestations), 'CSM': csmOperators?.missing_source, 'Overall Network': overallNetwork?.missing_source},
+                        ] : [
+                            {name: 'Source', [cleanedName]: (1 - entity.count_missing_source / entity.count_expected_attestations), 'Overall Network': overallNetwork?.missing_source},
+                        ]}
+                        legend={false}
+                    ></BarChartComponent>
+                </div>
+                <div className="3xs:h-[200px] lg:h-[300px] 3xs:w-[250px] 3xs:mx-auto" >
+                    <BarChartComponent
+                        data={checkCsm ? [
+                            {name: 'Target', [cleanedName]: (1 - entity.count_missing_target / entity.count_expected_attestations), 'CSM': csmOperators?.missing_target, 'Overall Network': overallNetwork?.missing_target},
+                        ] : [
+                            {name: 'Target', [cleanedName]: (1 - entity.count_missing_target / entity.count_expected_attestations), 'Overall Network': overallNetwork?.missing_target},
+                        ]}
+                        legend={false}
+                    ></BarChartComponent>
+                </div>
+                <div className="3xs:h-[220px] lg:h-[300px] 3xs:w-[250px] 3xs:mx-auto" >
+                    <BarChartComponent
+                        data={checkCsm ? [
+                            {name: 'Head', [cleanedName]: (1 - entity.count_missing_head / entity.count_expected_attestations), 'CSM': csmOperators?.missing_head, 'Overall Network': overallNetwork?.missing_head},
+                        ] : [
+                            {name: 'Head', [cleanedName]: (1 - entity.count_missing_head / entity.count_expected_attestations), 'Overall Network': overallNetwork?.missing_head},
+                        ]}
+                        legend={true}
+                    ></BarChartComponent>
+                </div>
+            </div>
+        )
+    }
+
+    const getCorrectnessComparisonLargeView = (entity: Entity, overallNetwork: Metrics, csmOperators: Metrics) => {
+        return (
+            <div className='lg:flex-row gap-y-2 md:gap-y-0 md:mb-0'>
+                <p className='text-[18px] md:w-[240px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>
+                    Correctness Comparison:
+                </p>
+                <div className="3xs:h-[200px] xs:h-[300px] md:w-[600px] ml:w-[750px] lg:w-[850px] xl:w-[1100px] 3xs:w-[355px] 2xs:w-[415px] xs:w-[520px] xl:mx-auto 3xs:ml-[-54px] md:ml-[-40px]" >
+                    <BarChartComponent
+                        data={checkCsm ? [
+                            {name: 'Source', [cleanedName]: (1 - entity.count_missing_source / entity.count_expected_attestations), 'CSM': csmOperators?.missing_source, 'Overall Network': overallNetwork?.missing_source},
+                            {name: 'Target', [cleanedName]: (1 - entity.count_missing_target / entity.count_expected_attestations), 'CSM': csmOperators?.missing_target, 'Overall Network': overallNetwork?.missing_target},
+                            {name: 'Head', [cleanedName]: (1 - entity.count_missing_head / entity.count_expected_attestations), 'CSM': csmOperators?.missing_head, 'Overall Network': overallNetwork?.missing_head},
+                        ] : [
+                            {name: 'Source', [cleanedName]: (1 - entity.count_missing_source / entity.count_expected_attestations), 'Overall Network': overallNetwork?.missing_source},
+                            {name: 'Target', [cleanedName]: (1 - entity.count_missing_target / entity.count_expected_attestations), 'Overall Network': overallNetwork?.missing_target},
+                            {name: 'Head', [cleanedName]: (1 - entity.count_missing_head / entity.count_expected_attestations), 'Overall Network': overallNetwork?.missing_head},
+                        ]}
+                    ></BarChartComponent>
+                </div>
+            </div>
+        );
+    }
 
     // Container Entity Performance
     const getEntityPerformance = (entity: Entity, overallNetwork: Metrics, csmOperators: Metrics, partRate: any, partRateCsm: any, partRateOverall: any) => {
@@ -305,30 +367,14 @@ const EntityComponent = ({ name, network }: Props) => {
                     </div>
                 </div>
 
-                <div className='lg:flex-row gap-y-2 md:gap-y-0 md:mb-0'>
-                    <p className='text-[18px] md:w-[240px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>
-                        Correctness Comparison:
-                    </p>
-                    <div className="3xs:h-[200px] xs:h-[300px] md:w-[600px] ml:w-[750px] lg:w-[850px] xl:w-[1100px] 3xs:w-[355px] 2xs:w-[415px] xs:w-[520px] xl:mx-auto 3xs:ml-[-54px] md:ml-[-40px]" >
-                        <BarChartComponent
-                            data={checkCsm ? [
-                                {name: 'Source', [cleanedName]: (1 - entity.count_missing_source / entity.count_expected_attestations), 'CSM': csmOperators?.missing_source, 'Overall Network': overallNetwork?.missing_source},
-                                {name: 'Target', [cleanedName]: (1 - entity.count_missing_target / entity.count_expected_attestations), 'CSM': csmOperators?.missing_target, 'Overall Network': overallNetwork?.missing_target},
-                                {name: 'Head', [cleanedName]: (1 - entity.count_missing_head / entity.count_expected_attestations), 'CSM': csmOperators?.missing_head, 'Overall Network': overallNetwork?.missing_head},
-                            ] : [
-                                {name: 'Source', [cleanedName]: (1 - entity.count_missing_source / entity.count_expected_attestations), 'Overall Network': overallNetwork?.missing_source},
-                                {name: 'Target', [cleanedName]: (1 - entity.count_missing_target / entity.count_expected_attestations), 'Overall Network': overallNetwork?.missing_target},
-                                {name: 'Head', [cleanedName]: (1 - entity.count_missing_head / entity.count_expected_attestations), 'Overall Network': overallNetwork?.missing_head},
-                            ]}
-                        ></BarChartComponent>
-                    </div>
-                </div>
+                {isLargeView ? getCorrectnessComparisonLargeView(entity, overallNetwork, csmOperators)
+                            : getCorrectnessComparisonMobile(entity, overallNetwork, csmOperators)}
 
                 <div className='lg:flex-row gap-y-2 md:gap-y-0 md:mb-0'>
-                    <p className='text-[18px] md:w-[290px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>
+                    <p className='text-[18px] 3xs:w-[290px] my-auto text-[var(--black)] dark:text-[var(--white)] mx-auto'>
                         Participation Rate Comparison:
                     </p>
-                    <div className="3xs:h-[250px] xs:h-[300px] md:w-[400px] 3xs:w-[315px] xs:w-[520px] 3xs:mx-auto xl:mx-auto 3xs:ml-[-25px]" >
+                    <div className="3xs:h-[220px] lg:h-[300px] 3xs:w-[250px] 3xs:mx-auto xl:mx-auto lg:ml-[-25px]" >
                         <BarChartComponent
                             data={checkCsm ? [
                                 {name: '', [cleanedName]: partRate, 'CSM': partRateCsm, 'Overall Network': partRateOverall},


### PR DESCRIPTION
Fix:
- Ensure the Correctness Comparison chart displays properly on mobile devices
- Adjust the layout of `Source`, `Target` and `Head` in a row on mobile instead of appearing side by side

Before:
![Screenshot_20250128-143029](https://github.com/user-attachments/assets/027f80f1-d8ea-40df-9770-a74b1d9fc5ac)

Result:
![IMG_0599](https://github.com/user-attachments/assets/23b8c77c-e533-4b78-b7c0-8cdd70ff0cc2)
