### PR TITLE
[feat] Show Lido CSM in Explore only on Mainnet

### DIFF
--- a/packages/client/components/ui/Menu.tsx
+++ b/packages/client/components/ui/Menu.tsx
@@ -11,13 +11,17 @@ import axiosClient from '../../config/axios';
 const Menu = () => {
     // States
     const [isOpen, setIsOpen] = useState(false);
-    const [networks, setNetworks] = useState([]);
+    const [networks, setNetworks] = useState<string[]>([]);
+    const [currentNetwork, setCurrentNetwork] = useState<string | null>(null);
 
+    
     useEffect(() => {
         if (networks.length === 0) {
             getNetworks();
         }
-
+        const network = new URLSearchParams(window.location.search).get('network');
+        setCurrentNetwork(network);
+        
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
@@ -60,19 +64,23 @@ const Menu = () => {
                 name: 'Clients',
                 route: '/clients',
             },
-            {
-                name: 'Lido CSM',
-                route: '/lido-csm',
-            },
+            ...(currentNetwork?.includes('mainnet')
+                ? [
+                    {
+                        name: 'Lido CSM',
+                        route: '/lido-csm',
+                    },
+                ]
+                : []),
         ],
         Networks:
             networks.length > 0
                 ? networks.map((network: string) => {
-                      return {
-                          name: network.charAt(0).toUpperCase() + network.slice(1),
-                          route: `/?network=${network}`,
-                      };
-                  })
+                    return {
+                        name: network.charAt(0).toUpperCase() + network.slice(1),
+                        route: `/?network=${network}`,
+                    };
+                })
                 : [],
     };
 


### PR DESCRIPTION
Feature:
- The Lido CSM option in the Explore dropdown is now only visible on the Mainnet network.

Results:
![image](https://github.com/user-attachments/assets/dd161e2f-30c9-40b9-87d8-f13b85365cc0)
![image](https://github.com/user-attachments/assets/09536324-06c2-42fa-837c-c596ddaeb2bb)