### PR TITLE
[feat] Add Slashings option to Explore dropdown

### DIFF
--- a/packages/client/components/ui/Menu.tsx
+++ b/packages/client/components/ui/Menu.tsx
@@ -64,6 +64,10 @@ const Menu = () => {
                 name: 'Clients',
                 route: '/clients',
             },
+            {
+                name: 'Slashings',
+                route: '/slashed_validators',
+            },
             ...(currentNetwork?.includes('mainnet')
                 ? [
                     {

--- a/packages/client/components/ui/Menu.tsx
+++ b/packages/client/components/ui/Menu.tsx
@@ -53,6 +53,10 @@ const Menu = () => {
                 route: '/validators',
             },
             {
+                name: 'Slashings',
+                route: '/slashed_validators',
+            },
+            {
                 name: 'Blocks',
                 route: '/blocks',
             },
@@ -63,10 +67,6 @@ const Menu = () => {
             {
                 name: 'Clients',
                 route: '/clients',
-            },
-            {
-                name: 'Slashings',
-                route: '/slashed_validators',
             },
             ...(currentNetwork?.includes('mainnet')
                 ? [


### PR DESCRIPTION
Feature:
- Add a new `Slashings` option to the `Explore` dropdown
- `Slashings` option links to the `/slashed_validators` route

Result:
![image](https://github.com/user-attachments/assets/1625352a-5cba-49bf-8371-2eea6f0a3a19)
