### PR TITLE
[feat] Clean entity name

### DIFF
--- a/packages/client/components/ui/EntityCard.tsx
+++ b/packages/client/components/ui/EntityCard.tsx
@@ -39,7 +39,7 @@ const EntityCard = ({ activeValidators, pool }: Props) => {
 
                 <div className='flex flex-col items-center md:items-start'>
                     <span className='text-[12px] md:text-[16px] font-semibold uppercase text-center md:text-start md:w-[100%] break-all'>
-                        {pool}
+                        {pool.replace('_', ' ')}
                     </span>
 
                     <span className='font-light text-[14px] md:text-[16px]'>


### PR DESCRIPTION
Feature:
- replace '_' by ' ' in the EntityCard

Before:
![image](https://github.com/user-attachments/assets/43682d72-a66e-40d8-ab8e-5e7dd0ce2ab4)

Result:
![image](https://github.com/user-attachments/assets/3f604128-7ddd-4c6e-a2f9-dc46ad510ec4)
